### PR TITLE
Add Phase 1 SwirlSystem starter files

### DIFF
--- a/swirl-system/css/base.css
+++ b/swirl-system/css/base.css
@@ -1,0 +1,44 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 20px;
+  background-color: #f8f8f8;
+  color: #333;
+}
+
+form {
+  margin-bottom: 20px;
+}
+
+label {
+  display: block;
+  margin-top: 10px;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 8px;
+  margin-top: 4px;
+  box-sizing: border-box;
+}
+
+#crumb-list {
+  list-style: none;
+  padding: 0;
+}
+
+#crumb-list li {
+  background: #fff;
+  border: 1px solid #ddd;
+  margin-bottom: 10px;
+  padding: 10px;
+}
+
+#crumb-list img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin-bottom: 5px;
+}

--- a/swirl-system/index.html
+++ b/swirl-system/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>SwirlSystem</title>
+  <link rel="stylesheet" href="css/base.css">
+</head>
+<body>
+  <h1>SwirlSystem</h1>
+  <form id="crumb-form">
+    <label for="photo">Photo</label>
+    <input type="file" id="photo" accept="image/*">
+
+    <label for="caption">Caption</label>
+    <textarea id="caption"></textarea>
+
+    <label for="pillar">Pillar</label>
+    <select id="pillar">
+      <option value="divine">👑 Divine Education</option>
+      <option value="family">🏡 Family &amp; Home</option>
+      <option value="self">🌱 Self + Parts</option>
+      <option value="rrr">📚 RRR</option>
+      <option value="work">💵 Employment &amp; Future</option>
+    </select>
+
+    <label for="part">Part (optional)</label>
+    <input type="text" id="part">
+
+    <button type="submit">Drop Crumb</button>
+  </form>
+
+  <ul id="crumb-list"></ul>
+
+  <script type="module" src="js/crumb-entry.js"></script>
+</body>
+</html>

--- a/swirl-system/js/crumb-entry.js
+++ b/swirl-system/js/crumb-entry.js
@@ -1,0 +1,59 @@
+import { loadCrumbs, saveCrumbs } from './storage.js';
+
+const PILLAR_LABELS = {
+  divine: '👑 Divine Education',
+  family: '🏡 Family & Home',
+  self: '🌱 Self + Parts',
+  rrr: '📚 RRR',
+  work: '💵 Employment & Future',
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('crumb-form');
+  const list = document.getElementById('crumb-list');
+  let crumbs = loadCrumbs();
+  crumbs.forEach(renderCrumb);
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const fileInput = document.getElementById('photo');
+    const caption = document.getElementById('caption').value.trim();
+    const pillarSelect = document.getElementById('pillar');
+    const pillar = pillarSelect.value;
+    const part = document.getElementById('part').value.trim();
+    const newCrumb = { id: Date.now(), caption, pillar, part };
+    const file = fileInput.files[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = () => {
+        newCrumb.image = reader.result;
+        crumbs.push(newCrumb);
+        saveCrumbs(crumbs);
+        renderCrumb(newCrumb);
+        form.reset();
+      };
+      reader.readAsDataURL(file);
+    } else {
+      crumbs.push(newCrumb);
+      saveCrumbs(crumbs);
+      renderCrumb(newCrumb);
+      form.reset();
+    }
+  });
+
+  function renderCrumb(crumb) {
+    const li = document.createElement('li');
+    if (crumb.image) {
+      const img = document.createElement('img');
+      img.src = crumb.image;
+      img.alt = crumb.caption || '';
+      li.appendChild(img);
+    }
+    const text = document.createElement('p');
+    const partText = crumb.part ? ` (${crumb.part})` : '';
+    const pillarLabel = PILLAR_LABELS[crumb.pillar] || crumb.pillar;
+    text.textContent = `${pillarLabel}: ${crumb.caption}${partText}`;
+    li.appendChild(text);
+    list.appendChild(li);
+  }
+});

--- a/swirl-system/js/storage.js
+++ b/swirl-system/js/storage.js
@@ -1,0 +1,13 @@
+const STORAGE_KEY = 'swirl_crumbs';
+
+export function loadCrumbs() {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveCrumbs(crumbs) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(crumbs));
+}


### PR DESCRIPTION
## Summary
- add minimal SwirlSystem index page with crumb entry form
- include base styles for layout and simple list styling
- provide storage and entry scripts for saving crumbs to localStorage
- refine crumb entry for accessibility and consistent pillar values

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f3fb35c0832eba401299eb506c67