### PR TITLE
Add comments, PIN gating, and weekly summaries

### DIFF
--- a/jonah-swirl/css/blooms.css
+++ b/jonah-swirl/css/blooms.css
@@ -1,0 +1,30 @@
+.bloom-grid{
+  display:grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 12px;
+}
+
+.bloom{
+  display:flex; align-items:center; gap:10px;
+  padding: 8px 10px;
+  background: rgba(255,255,255,.8);
+  border: 2px solid var(--accent1);
+  border-radius: 14px;
+}
+
+.bloom .dot{
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  background: var(--accent2); /* default */
+  box-shadow: 0 0 0 3px rgba(143,213,196,.25);
+}
+
+.bloom .name{ font-weight: 600; }
+.bloom .count{ margin-left:auto; opacity:.8; }
+
+/* Optional pillar tinting for dots */
+.bloom[data-pillar="divine"] .dot{ background: var(--accent1); }
+.bloom[data-pillar="family"] .dot{ background: var(--accent2); }
+.bloom[data-pillar="self"]   .dot{ background: var(--accent1); }
+.bloom[data-pillar="rrr"]    .dot{ background: var(--accent2); }
+.bloom[data-pillar="work"]   .dot{ background: var(--accent3); }

--- a/jonah-swirl/css/day.css
+++ b/jonah-swirl/css/day.css
@@ -42,3 +42,33 @@ input:focus, select:focus, textarea:focus{
   padding:10px 8px; border-bottom:1px dashed rgba(0,0,0,.08);
 }
 #todayUl li:last-child{ border-bottom:0; }
+/* Crumb rows + comments */
+.c-top{ display:flex; gap:8px; align-items:flex-start; justify-content:space-between; }
+.c-text{ white-space:pre-wrap; }
+
+.c-comments-wrap{ margin-top:8px; }
+.c-comments{ list-style:none; padding:0; margin:0 0 6px 0; }
+.c-comments li{ padding:6px 0; border-bottom:1px dashed rgba(0,0,0,.08); }
+.c-comments li:last-child{ border-bottom:0; }
+
+.c-add input{
+  width:100%;
+  padding:.7rem 1rem;
+  border-radius:12px;
+  border:2px solid rgba(0,0,0,.06);
+}
+.c-add input:focus{
+  border-color: var(--accent1);
+  box-shadow: 0 0 0 3px rgba(143,213,196,.25);
+}
+
+/* PIN modal */
+.pin-backdrop{
+  position:fixed; inset:0; background: rgba(0,0,0,.25);
+  display:flex; align-items:center; justify-content:center; z-index: 999;
+}
+.pin-modal.card{
+  width:min(520px, 92vw);
+}
+.pin-block{ margin:10px 0; }
+.pin-actions{ display:flex; gap:8px; justify-content:flex-end; }

--- a/jonah-swirl/css/weekly.css
+++ b/jonah-swirl/css/weekly.css
@@ -1,0 +1,41 @@
+body { margin:0; background: var(--bg); color: var(--ink); }
+
+.wrap{
+  max-width: 920px;
+  margin: 0 auto;
+  padding: clamp(14px, 3vw, 24px);
+}
+
+.head{
+  display:flex; align-items:center; gap:12px; flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+.head h1{ margin:0; font-size: clamp(20px, 3.6vw, 28px); }
+.head-actions{ margin-left:auto; display:flex; gap:8px; flex-wrap:wrap; }
+
+.card{
+  background: rgba(255,255,255,.9);
+  border: 2px solid var(--accent1);
+  border-radius: var(--radius);
+  box-shadow: 0 10px 24px var(--shadow);
+  padding: 14px;
+  margin: 12px 0;
+}
+
+.hint{ opacity:.7; font-size:.92rem; margin:.25rem 0 0 0; }
+
+.bars{
+  display:grid;
+  grid-template-columns: 1fr;
+  gap:10px;
+}
+.bar{
+  display:grid;
+  grid-template-columns: 120px 1fr auto;
+  gap:10px; align-items:center;
+}
+.bar .label{ opacity:.9; }
+.bar .track{ background: rgba(0,0,0,.06); border-radius: 999px; height: 14px; overflow:hidden; }
+.bar .fill{ height:100%; background: var(--accent1); }
+
+.export-actions{ display:flex; gap:10px; flex-wrap:wrap; }

--- a/jonah-swirl/day.html
+++ b/jonah-swirl/day.html
@@ -44,12 +44,69 @@
     </form>
 
     <section id="todayList" class="card">
-      <h2>Today</h2>
+      <div class="row" style="grid-template-columns: 1fr auto;">
+        <h2 style="margin:0;">Today</h2>
+        <button id="parentBtn" class="btn btn-ghost" type="button">Parent Controls</button>
+      </div>
       <ul id="todayUl" aria-live="polite"></ul>
     </section>
   </main>
 
   <script type="module" src="./js/storage.js"></script>
   <script type="module" src="./js/crumb-entry.js"></script>
+  <script type="module" src="./js/pin.js"></script>
+  <script type="module">
+    import { todayCrumbs } from './js/storage.js';
+    import { renderCommentsFor, mountCommentForm, handleDelete } from './js/comments.js';
+
+    const list = document.getElementById('todayUl');
+    const parentBtn = document.getElementById('parentBtn');
+
+    // Parent controls: set/change PIN
+    parentBtn.addEventListener('click', ()=>{
+      window.pinPrompt?.({ mode:'set', onOk(){ /* no-op; modal reports success */ } });
+    });
+
+    function makeRow(c){
+      const li = document.createElement('li');
+      li.dataset.id = c.id;
+
+      // Row content
+      const emoji = { divine:'👑', family:'🏠', self:'🌱', rrr:'📚', work:'💵' }[c.pillar] || '•';
+      li.innerHTML = `
+      <div class="c-top">
+        <div class="c-text">${emoji} ${escapeHtml(c.text)}</div>
+        <div class="c-actions">
+          <button class="btn btn-ghost c-del" type="button" title="Delete">Delete</button>
+        </div>
+      </div>
+      <div class="c-comments-wrap">
+        <ul class="c-comments"></ul>
+        <form class="c-add"><input placeholder="Add a comment…" maxlength="160"></form>
+      </div>
+      `;
+
+      // Wire comments
+      const commentsUl = li.querySelector('.c-comments');
+      const addForm = li.querySelector('.c-add');
+      renderCommentsFor(commentsUl, c.id);
+      mountCommentForm(addForm, c.id, ()=> renderCommentsFor(commentsUl, c.id));
+
+      // Wire delete (PIN-gated)
+      const delBtn = li.querySelector('.c-del');
+      handleDelete(delBtn, c.id, renderList);
+
+      return li;
+    }
+
+    function renderList(){
+      list.innerHTML = '';
+      todayCrumbs().forEach(c=> list.appendChild(makeRow(c)));
+    }
+
+    function escapeHtml(s){ return (s||'').replace(/[&<>"']/g, m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;', "'":'&#39;' }[m])); }
+
+    renderList();
+  </script>
 </body>
 </html>

--- a/jonah-swirl/js/blooms.js
+++ b/jonah-swirl/js/blooms.js
@@ -1,0 +1,116 @@
+// Blooms + Weekly summary utilities (neutral wireframe)
+// Depends on Storage helpers from storage.js
+
+import { listCrumbs } from './storage.js';
+
+/** ISO week window (Mon 00:00:00 to Sun 23:59:59.999) for a given offset from current week */
+export function weekWindow(offset = 0){
+  const now = new Date();
+  // get Monday of this week
+  const day = (now.getDay() + 6) % 7; // 0=Mon ... 6=Sun
+  const monday = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate() - day));
+  // apply offset in weeks
+  const start = new Date(monday.getTime() + offset * 7 * 86400000);
+  const end   = new Date(start.getTime() + 6 * 86400000);
+  // normalize to local midnight boundaries for label/output (we keep ISO date-only in summaries)
+  return { start, end };
+}
+
+/** Format YYYY-MM-DD */
+export function ymd(d){
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate()).toISOString().slice(0,10);
+}
+
+export function isoLabel(d){
+  return ymd(d);
+}
+
+/** Summarize crumbs in [start,end] inclusive, grouped by pillar and by tag */
+export function summarizeWeek(start, end){
+  const s = ymd(start), e = ymd(end);
+  const crumbs = listCrumbs().filter(c=> {
+    const d = (c.tsISO||'').slice(0,10);
+    return d >= s && d <= e;
+  });
+
+  const pillars = { divine:0, family:0, self:0, rrr:0, work:0 };
+  const tagCounts = new Map(); // tag -> count
+  const tagPillar = new Map(); // tag -> pillar that co-occurs most often
+
+  // count by pillar + tags
+  for(const c of crumbs){
+    pillars[c.pillar] = (pillars[c.pillar]||0) + 1;
+    const tags = Array.isArray(c.tags) ? c.tags : [];
+    for(const t of tags){
+      const key = t.toLowerCase();
+      tagCounts.set(key, (tagCounts.get(key)||0) + 1);
+      // naive pillar association: increment per tag-pillar pair
+      const k2 = key+'|'+(c.pillar||'');
+      tagPillar.set(k2, (tagPillar.get(k2)||0) + 1);
+    }
+  }
+
+  // determine dominant pillar per tag
+  const tagToPillar = {};
+  for(const [tp, cnt] of tagPillar.entries()){
+    const [tag, pillar] = tp.split('|');
+    if(!tagToPillar[tag] || cnt > tagToPillar[tag].cnt){
+      tagToPillar[tag] = { pillar, cnt };
+    }
+  }
+
+  // produce sorted top tags (limit 24)
+  const tags = [...tagCounts.entries()]
+    .sort((a,b)=> b[1]-a[1])
+    .slice(0,24)
+    .map(([name, count])=> ({ name, count, pillar: (tagToPillar[name]?.pillar)||'' }));
+
+  return { range:{start:s, end:e}, total: crumbs.length, pillars, tags };
+}
+
+/** Render pillar bars */
+export function renderPillarBars(root, pillars){
+  root.innerHTML = '';
+  const total = Object.values(pillars).reduce((a,b)=>a+b,0) || 1;
+  const labels = {
+    divine:'👑 Divine', family:'🏠 Home', self:'🌱 Self', rrr:'📚 Skills', work:'💵 Work'
+  };
+  Object.keys(labels).forEach(key=>{
+    const c = pillars[key]||0;
+    const pct = Math.round(c*100/total);
+    const row = document.createElement('div');
+    row.className = 'bar';
+    row.innerHTML = `
+      <div class="label">${labels[key]}</div>
+      <div class="track"><div class="fill" style="width:${pct}%"></div></div>
+      <div class="val">${c}</div>
+    `;
+    root.appendChild(row);
+  });
+}
+
+/** Render tag blooms (dot scales by count) */
+export function renderBlooms(root, tags){
+  root.innerHTML = '';
+  if(!tags.length){
+    root.innerHTML = `<p class="hint">No tags yet this week. Try adding a few on the Day page.</p>`;
+    return;
+  }
+  const max = Math.max(...tags.map(t=>t.count));
+  for(const t of tags){
+    const dot = Math.max(18, Math.round(18 + (t.count/max)*22)); // 18..40px
+    const div = document.createElement('div');
+    div.className = 'bloom';
+    if(t.pillar) div.dataset.pillar = t.pillar;
+    div.innerHTML = `
+      <div class="dot" style="width:${dot}px;height:${dot}px;"></div>
+      <div class="name">${escapeHtml(t.name)}</div>
+      <div class="count">${t.count}</div>
+    `;
+    root.appendChild(div);
+  }
+}
+
+export function gotoWeek(offset){ /* reserved for external controls */ }
+
+function escapeHtml(s){ return (s||'').replace(/[&<>"']/g, m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;', "'":'&#39;' }[m])); }

--- a/jonah-swirl/js/comments.js
+++ b/jonah-swirl/js/comments.js
@@ -1,0 +1,44 @@
+import { addComment, commentsFor, deleteCrumb, listCrumbs } from './storage.js';
+
+/* Minimal comment wiring for the Day page.
+   - Assumes each crumb row has data-id and containers:
+     .c-actions (buttons), .c-comments (list), .c-add (form)
+*/
+export function renderCommentsFor(container, crumbId){
+  const list = commentsFor(crumbId);
+  container.innerHTML = '';
+  list.sort((a,b)=>(a.tsISO||'').localeCompare(b.tsISO||'')).forEach(m=>{
+    const li = document.createElement('li');
+    li.textContent = m.text;
+    container.appendChild(li);
+  });
+}
+
+export function mountCommentForm(formEl, crumbId, onAdded){
+  const input = formEl.querySelector('input');
+  formEl.addEventListener('submit', (e)=>{
+    e.preventDefault();
+    const t = (input.value||'').trim();
+    if(!t) return;
+    addComment({crumbId, text:t});
+    input.value = '';
+    onAdded?.();
+  });
+}
+
+export function handleDelete(btnEl, crumbId, refresh){
+  btnEl.addEventListener('click', ()=>{
+    // Require PIN first
+    if(typeof window.pinPrompt !== 'function'){ alert('PIN module missing'); return; }
+    window.pinPrompt({mode:'verify', onOk(){
+      deleteCrumb(crumbId);
+      refresh?.();
+    }});
+  });
+}
+
+// Utility to re-render a generic crumb list when deletions happen
+export function refreshList(listRoot, makeRow){
+  listRoot.innerHTML = '';
+  listCrumbs().forEach(c=> listRoot.appendChild(makeRow(c)));
+}

--- a/jonah-swirl/js/export.js
+++ b/jonah-swirl/js/export.js
@@ -1,0 +1,51 @@
+// Weekly export (JSON + CSV) from the summary produced in blooms.js
+// No mutation; just creates a downloadable file via Blob.
+
+function fmtDate(d){
+  // d is Date
+  const y = d.getFullYear();
+  const m = String(d.getMonth()+1).padStart(2,'0');
+  const dd= String(d.getDate()).padStart(2,'0');
+  return `${y}-${m}-${dd}`;
+}
+
+export function downloadJson(summary, start, end){
+  const data = {
+    title: `Jonah Weekly Glow ${fmtDate(start)} to ${fmtDate(end)}`,
+    generatedAt: new Date().toISOString(),
+    range: summary.range,
+    counts: { pillars: summary.pillars, total: summary.total },
+    tags: summary.tags
+  };
+  const blob = new Blob([JSON.stringify(data, null, 2)], {type:'application/json'});
+  trigger(blob, `jonah_week_${fmtDate(start)}_${fmtDate(end)}.json`);
+}
+
+export function downloadCsv(summary, start, end){
+  const rows = [];
+  rows.push(['week_start','week_end','total'].join(','));
+  rows.push([fmtDate(start), fmtDate(end), summary.total].join(','));
+  rows.push('');
+  rows.push(['pillar','count'].join(','));
+  Object.entries(summary.pillars).forEach(([k,v])=> rows.push([k,v].join(',')));
+  rows.push('');
+  rows.push(['tag','count','pillar'].join(','));
+   summary.tags.forEach(t=> rows.push([csv(t.name), t.count, t.pillar||''].join(',')));
+
+  const blob = new Blob([rows.join('\n')], {type:'text/csv'});
+  trigger(blob, `jonah_week_${fmtDate(start)}_${fmtDate(end)}.csv`);
+}
+
+function csv(s){
+  const v = (s||'').replaceAll('"','""');
+  return /[",\n]/.test(v) ? `"${v}"` : v;
+}
+
+function trigger(blob, filename){
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  setTimeout(()=>{ URL.revokeObjectURL(a.href); a.remove(); }, 0);
+}

--- a/jonah-swirl/js/pin.js
+++ b/jonah-swirl/js/pin.js
@@ -1,0 +1,76 @@
+import { pinExists, verifyPin, setPin } from './storage.js';
+
+/* Lightweight PIN modal injected at runtime.
+   Use: pinPrompt({mode:'verify'|'set', onOk(pin){...}})
+*/
+(function(){
+  const tpl = `
+  <div class="pin-backdrop" data-pin>
+    <div class="pin-modal card">
+      <h2 id="pinTitle">Parent PIN</h2>
+      <form id="pinForm">
+        <div id="pinSetBlock" class="pin-block">
+          <label class="row"><span class="lab">New PIN</span><input id="pinNew" type="password" inputmode="numeric" autocomplete="new-password" required></label>
+          <label class="row"><span class="lab">Confirm</span><input id="pinNew2" type="password" inputmode="numeric" autocomplete="new-password" required></label>
+        </div>
+        <div id="pinVerifyBlock" class="pin-block">
+          <label class="row"><span class="lab">PIN</span><input id="pinInput" type="password" inputmode="numeric" autocomplete="current-password" required></label>
+        </div>
+        <div id="pinCurrentBlock" class="pin-block">
+          <label class="row"><span class="lab">Current</span><input id="pinCurrent" type="password" inputmode="numeric" autocomplete="current-password"></label>
+        </div>
+        <div class="pin-actions">
+          <button class="btn" type="submit">OK</button>
+          <button class="btn btn-ghost" type="button" id="pinCancel">Cancel</button>
+        </div>
+        <p id="pinMsg" role="alert" style="margin:8px 0 0 0;"></p>
+      </form>
+    </div>
+  </div>`;
+
+  function ensureModal(){
+    if(document.querySelector('[data-pin]')) return;
+    const div = document.createElement('div');
+    div.innerHTML = tpl.trim();
+    document.body.appendChild(div.firstElementChild);
+    document.getElementById('pinCancel').addEventListener('click', close);
+    document.querySelector('[data-pin]').addEventListener('click', e=>{ if(e.target.hasAttribute('data-pin')) close();});
+  }
+
+  function close(){ const el = document.querySelector('[data-pin]'); if(el) el.remove(); }
+
+   function show(opts){
+    ensureModal();
+    const setMode = (opts?.mode === 'set');
+    const hasPin = pinExists();
+
+    document.getElementById('pinTitle').textContent = setMode ? 'Set/Change Parent PIN' : 'Parent PIN';
+    document.getElementById('pinSetBlock').style.display = setMode ? '' : 'none';
+    document.getElementById('pinVerifyBlock').style.display = setMode ? 'none' : '';
+    document.getElementById('pinCurrentBlock').style.display = (setMode && hasPin) ? '' : 'none';
+    document.getElementById('pinMsg').textContent = '';
+
+    const form = document.getElementById('pinForm');
+    form.onsubmit = (e)=>{
+      e.preventDefault();
+      const msg = document.getElementById('pinMsg');
+
+      if(setMode){
+        const new1 = document.getElementById('pinNew').value.trim();
+        const new2 = document.getElementById('pinNew2').value.trim();
+        const cur  = document.getElementById('pinCurrent').value.trim();
+        if(!new1 || new1 !== new2){ msg.textContent = 'Pins must match.'; return; }
+        const res = setPin(new1, cur);
+        if(!res.ok){ msg.textContent = 'Current PIN incorrect.'; return; }
+        close(); opts?.onOk?.(new1); return;
+      } else {
+        const pin = document.getElementById('pinInput').value.trim();
+        if(!verifyPin(pin)){ msg.textContent = 'Wrong PIN.'; return; }
+        close(); opts?.onOk?.(pin); return;
+      }
+    };
+  }
+
+  // expose globally
+  window.pinPrompt = show;
+})();

--- a/jonah-swirl/js/storage.js
+++ b/jonah-swirl/js/storage.js
@@ -1,5 +1,5 @@
 // Simple local storage layer for Jonah (Phase 1: local-first)
-// Keys are namespaced so Mom's hub won't clash.
+// Namespaced keys so Mom's hub won't clash.
 const KEYS = {
   crumbs: 'swirl_crumbs_jonah',
   comments: 'swirl_comments_jonah',
@@ -8,37 +8,70 @@ const KEYS = {
 };
 
 const Storage = {
-  _load(key){ try{ return JSON.parse(localStorage.getItem(key) || '[]'); }catch{ return []; } },
+  _load(key, fallback = '[]'){ try{ return JSON.parse(localStorage.getItem(key) || fallback); }catch{ return JSON.parse(fallback); } },
   _save(key, val){ localStorage.setItem(key, JSON.stringify(val)); },
 
+  // --- Crumbs ---
   getCrumbs(){ return this._load(KEYS.crumbs); },
   addCrumb(crumb){
-    const list = this.getCrumbs();
-    list.push(crumb);
+    const list = this.getCrumbs(); list.push(crumb);
     this._save(KEYS.crumbs, list);
     this.audit('create','crumb', crumb.id, {pillar:crumb.pillar, text:crumb.text.slice(0,80)});
     return crumb;
   },
+  deleteCrumbById(id){
+    const list = this.getCrumbs();
+    const idx = list.findIndex(c=>c.id===id);
+    if(idx>=0){
+      const removed = list.splice(idx,1)[0];
+      this._save(KEYS.crumbs, list);
+      this.audit('delete','crumb', id, {pillar:removed?.pillar});
+      return true;
+    }
+    return false;
+  },
 
+  // --- Comments ---
   getComments(){ return this._load(KEYS.comments); },
+  getCommentsFor(crumbId){ return this.getComments().filter(c=>c.crumbId===crumbId); },
   addComment(c){
     const list = this.getComments(); list.push(c);
     this._save(KEYS.comments, list);
-    this.audit('create','comment', c.id, {crumbId:c.crumbId});
+    this.audit('create','comment', c.id, {crumbId:c.crumbId, author:c.author});
+    return c;
   },
 
+  // --- Settings (PIN + Shoeday) ---
   settings(){
-    try{
-      return JSON.parse(localStorage.getItem(KEYS.settings) || '{"shoeday":"0","pin":""}');
-    }catch{
-      return { shoeday:'0', pin:'' };
-    }
+    return this._load(KEYS.settings, '{"shoeday":"0","pin":""}');
   },
   setSetting(name, value){
     const s = this.settings(); s[name] = value;
     localStorage.setItem(KEYS.settings, JSON.stringify(s));
   },
+  pinExists(){ return !!(this.settings().pin || '').trim(); },
+  verifyPin(input){
+    const set = (this.settings().pin || '').trim();
+    const ok = set === (input || '').trim();
+    this.audit(ok?'pin_ok':'pin_fail','pin','settings',{});
+    return ok;
+  },
+  setPin(newPin, currentPin = ''){
+    const s = this.settings();
+    // If a PIN exists, require the current one to match
+    if ((s.pin || '').trim()){
+      if ((s.pin || '').trim() !== (currentPin || '').trim()){
+        this.audit('pin_fail','pin','settings',{reason:'bad_current'});
+        return {ok:false, reason:'bad_current'};
+      }
+    }
+    s.pin = (newPin || '').trim();
+    localStorage.setItem(KEYS.settings, JSON.stringify(s));
+    this.audit('pin_set','pin','settings',{});
+    return {ok:true};
+  },
 
+  // --- Audit ---
   audit(action, targetType, targetId, diff){
     const a = this._load(KEYS.audit);
     a.push({ tsISO:new Date().toISOString(), actor:'jonah', action, targetType, targetId, diff });
@@ -46,7 +79,7 @@ const Storage = {
   }
 };
 
-// Helpers used by day page
+// Helpers used by pages
 export function preselectPillarFromHash(selectEl){
   const h = (location.hash || '').replace('#','').trim();
   if(!h) return;
@@ -71,9 +104,17 @@ export function todayCrumbs(){
   return Storage.getCrumbs().filter(c=> (c.tsISO||'').slice(0,10) === today);
 }
 
-export function listCrumbs(){
-  return Storage.getCrumbs().slice().sort((a,b)=> (b.tsISO||'').localeCompare(a.tsISO||''));
+export function listCrumbs(){ return Storage.getCrumbs().slice().sort((a,b)=> (b.tsISO||'').localeCompare(a.tsISO||'')); }
+export function deleteCrumb(id){ return Storage.deleteCrumbById(id); }
+
+export function addComment({crumbId, text}){
+  const id = 'm_' + Math.random().toString(36).slice(2,9);
+  return Storage.addComment({ id, tsISO:new Date().toISOString(), crumbId, author:'jonah', text: text.trim() });
 }
+export function commentsFor(crumbId){ return Storage.getCommentsFor(crumbId); }
 
 export function settings(){ return Storage.settings(); }
 export function setSetting(name, value){ return Storage.setSetting(name,value); }
+export function pinExists(){ return Storage.pinExists(); }
+export function verifyPin(input){ return Storage.verifyPin(input); }
+export function setPin(newPin, currentPin){ return Storage.setPin(newPin, currentPin); }

--- a/jonah-swirl/weekly.html
+++ b/jonah-swirl/weekly.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Weekly Glow · Jonah</title>
+  <link rel="stylesheet" href="./css/base.css">
+  <link rel="stylesheet" href="./css/weekly.css">
+  <link rel="stylesheet" href="./css/blooms.css">
+</head>
+<body>
+  <main class="wrap">
+    <header class="head">
+      <a class="btn btn-ghost" href="./index.html">← Home</a>
+      <h1>Weekly Glow</h1>
+      <div class="head-actions">
+        <button id="prevWeek" class="btn btn-ghost" type="button">◀︎ Prev</button>
+        <button id="thisWeek" class="btn btn-ghost" type="button">This Week</button>
+        <button id="nextWeek" class="btn btn-ghost" type="button">Next ▶︎</button>
+      </div>
+    </header>
+
+    <section class="week-range card" aria-live="polite">
+      <h2 id="weekLabel">Week</h2>
+      <p class="hint">ISO week (Mon–Sun). Change in <code>blooms.js</code> if you prefer Sun–Sat.</p>
+    </section>
+
+    <!-- PILLAR COUNTS -->
+    <section class="pillars card">
+      <h2>By Pillar</h2>
+      <div id="pillarBars" class="bars"></div>
+    </section>
+
+    <!-- TAG BLOOMS -->
+    <section class="blooms card">
+      <h2>Blooms (Top Tags)</h2>
+      <div id="bloomGrid" class="bloom-grid" aria-live="polite"></div>
+      <p class="hint">Size = how often the tag appeared in crumbs this week.</p>
+    </section>
+
+    <!-- EXPORT -->
+    <section class="export card">
+      <h2>Export</h2>
+      <div class="export-actions">
+        <button id="btnJson" class="btn" type="button">Download JSON</button>
+        <button id="btnCsv"  class="btn" type="button">Download CSV</button>
+      </div>
+      <p class="hint">Exports are read-only snapshots. Your saved crumbs don’t change.</p>
+    </section>
+  </main>
+
+  <script type="module" src="./js/storage.js"></script>
+  <script type="module" src="./js/blooms.js"></script>
+  <script type="module" src="./js/export.js"></script>
+  <script type="module">
+    import { weekWindow, summarizeWeek, renderPillarBars, renderBlooms, gotoWeek, isoLabel } from './js/blooms.js';
+    import { downloadJson, downloadCsv } from './js/export.js';
+
+    // State: weekOffset = 0 -> this week; -1 prev; +1 next, etc.
+    let weekOffset = 0;
+
+    const weekLabel = document.getElementById('weekLabel');
+    const bars = document.getElementById('pillarBars');
+    const bloomGrid = document.getElementById('bloomGrid');
+    const prevBtn = document.getElementById('prevWeek');
+    const nextBtn = document.getElementById('nextWeek');
+    const thisBtn = document.getElementById('thisWeek');
+    const btnJson = document.getElementById('btnJson');
+    const btnCsv  = document.getElementById('btnCsv');
+
+    function render(){
+      const { start, end } = weekWindow(weekOffset);
+      const summary = summarizeWeek(start, end);
+      weekLabel.textContent = `Week: ${isoLabel(start)} – ${isoLabel(end)}`;
+      renderPillarBars(bars, summary.pillars);
+      renderBlooms(bloomGrid, summary.tags);
+      // export handlers depend on current summary
+      btnJson.onclick = ()=> downloadJson(summary, start, end);
+      btnCsv.onclick  = ()=> downloadCsv(summary, start, end);
+    }
+
+    prevBtn.onclick = ()=>{ weekOffset -= 1; render(); };
+    nextBtn.onclick = ()=>{ weekOffset += 1; render(); };
+    thisBtn.onclick = ()=>{ weekOffset  = 0; render(); };
+
+    // initial
+    render();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Enable commenting on crumbs with persistent storage and PIN-gated deletion
- Introduce parent PIN modal for verifying or changing controls
- Add Weekly Glow page showing pillar counts, tag blooms, and export to JSON/CSV

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a6e55a48832e8ce4f4ed411856d8