### PR TITLE
Add optional cloud sync, photo compression, and settings modal

### DIFF
--- a/jonah-swirl/css/settings.css
+++ b/jonah-swirl/css/settings.css
@@ -1,0 +1,45 @@
+/* Settings modal (neutral wireframe) */
+.settings-backdrop{
+  position:fixed; inset:0;
+  display:flex; align-items:center; justify-content:center;
+  background: rgba(0,0,0,.25);
+  z-index: 1000;
+}
+.settings-modal{
+  width:min(680px, 92vw);
+  background: rgba(255,255,255,.96);
+  border: 2px solid var(--accent1);
+  border-radius: var(--radius);
+  box-shadow: 0 12px 30px var(--shadow);
+  padding: 16px;
+}
+
+.settings-modal h2{ margin:0 0 6px; font-size: clamp(18px, 3.2vw, 22px); }
+.settings-modal .hint{ opacity:.75; margin:.25rem 0 .75rem 0; }
+
+.settings-section{
+  padding: 10px 0;
+  border-top: 1px dashed rgba(0,0,0,.12);
+}
+.settings-section:first-of-type{ border-top:0; }
+
+.row{ display:grid; grid-template-columns: 160px 1fr; gap:12px; align-items:center; margin:10px 0; }
+.lab{ opacity:.9; }
+
+input[type="text"], input[type="password"]{
+  width:100%; padding:.7rem 1rem; border-radius:12px;
+  border:2px solid rgba(0,0,0,.06); background:#fff; font-size:1rem;
+}
+input[type="text"]:focus, input[type="password"]:focus{
+  border-color: var(--accent1);
+  box-shadow: 0 0 0 3px rgba(143,213,196,.25);
+}
+
+.switch{
+  display:flex; align-items:center; gap:10px;
+}
+.switch input[type="checkbox"]{ width: 1.25rem; height: 1.25rem; }
+
+.settings-actions{
+  margin-top:12px; display:flex; gap:8px; justify-content:flex-end;
+}

--- a/jonah-swirl/day.html
+++ b/jonah-swirl/day.html
@@ -17,96 +17,113 @@
       <h1>Drop a Crumb</h1>
     </header>
 
-    <form id="crumbForm" class="card">
-      <label class="row">
-        <span class="lab">Pillar</span>
-        <select id="pillar" name="pillar" required>
-          <option value="divine">👑 Divine</option>
-          <option value="family">🏠 Home</option>
-          <option value="self">🌱 Self</option>
-          <option value="rrr">📚 Skills</option>
-          <option value="work">💵 Work</option>
-        </select>
-      </label>
+    <form id="crumbForm" class="card">
+      <label class="row">
+        <span class="lab">Pillar</span>
+        <select id="pillar" name="pillar" required>
+          <option value="divine">👑 Divine</option>
+          <option value="family">🏠 Home</option>
+          <option value="self">🌱 Self</option>
+          <option value="rrr">📚 Skills</option>
+          <option value="work">💵 Work</option>
+        </select>
+      </label>
 
-      <label class="row">
-        <span class="lab">What happened?</span>
-        <textarea id="text" name="text" rows="3" maxlength="280" placeholder="one line is enough 💛" required></textarea>
-      </label>
+      <label class="row">
+        <span class="lab">What happened?</span>
+        <textarea id="text" name="text" rows="3" maxlength="280" placeholder="one line is enough 💛" required></textarea>
+      </label>
 
-      <label class="row">
-        <span class="lab">Tags (optional)</span>
-        <input id="tags" name="tags" placeholder="comma, separated" />
-      </label>
+      <label class="row">
+        <span class="lab">Photo</span>
+        <input id="photo" type="file" accept="image/*" capture="environment">
+      </label>
 
-      <!-- Future: photo path / compression; parts[]; skills[] -->
-      <button class="btn" type="submit">Save Crumb</button>
-    </form>
+      <label class="row">
+        <span class="lab">Tags</span>
+        <input id="tags" name="tags" placeholder="comma, separated" />
+      </label>
 
-    <section id="todayList" class="card">
-      <div class="row" style="grid-template-columns: 1fr auto;">
-        <h2 style="margin:0;">Today</h2>
-        <button id="parentBtn" class="btn btn-ghost" type="button">Parent Controls</button>
-      </div>
-      <ul id="todayUl" aria-live="polite"></ul>
-    </section>
+      <button class="btn" type="submit">Save Crumb</button>
+    </form>
+
+    <section id="todayList" class="card">
+      <div class="row" style="grid-template-columns: 1fr auto auto;">
+        <h2 style="margin:0;">Today</h2>
+        <button id="openSettings" class="btn btn-ghost" type="button">⚙︎ Settings</button>
+        <button id="parentBtn" class="btn btn-ghost" type="button">Parent Controls</button>
+      </div>
+      <ul id="todayUl" aria-live="polite"></ul>
+    </section>
   </main>
 
-  <script type="module" src="./js/storage.js"></script>
-  <script type="module" src="./js/crumb-entry.js"></script>
-  <script type="module" src="./js/pin.js"></script>
-  <script type="module">
-    import { todayCrumbs } from './js/storage.js';
-    import { renderCommentsFor, mountCommentForm, handleDelete } from './js/comments.js';
+  <script type="module" src="./js/storage.js"></script>
+  <script type="module" src="./js/crumb-entry.js"></script>
+  <script type="module" src="./js/pin.js"></script>
+  <script type="module" src="./js/photos.js"></script>
+  <script type="module">
+    import { initSync } from './js/sync.js';
+    // Start listening to storage events for optional sync.
+    initSync();
+  </script>
+  <script type="module">
+    import { todayCrumbs } from './js/storage.js';
+    import { renderCommentsFor, mountCommentForm, handleDelete } from './js/comments.js';
 
-    const list = document.getElementById('todayUl');
-    const parentBtn = document.getElementById('parentBtn');
+    const list = document.getElementById('todayUl');
+    const parentBtn = document.getElementById('parentBtn');
 
-    // Parent controls: set/change PIN
+    // Parent controls: set/change PIN
     parentBtn.addEventListener('click', ()=>{
-      window.pinPrompt?.({ mode:'set', onOk(){ /* no-op; modal reports success */ } });
-    });
+      window.pinPrompt?.({ mode:'set', onOk(){ /* no-op; modal reports success */ } });
+    });
 
-    function makeRow(c){
-      const li = document.createElement('li');
-      li.dataset.id = c.id;
+    function makeRow(c){
+      const li = document.createElement('li');
+      li.dataset.id = c.id;
 
-      // Row content
-      const emoji = { divine:'👑', family:'🏠', self:'🌱', rrr:'📚', work:'💵' }[c.pillar] || '•';
-      li.innerHTML = `
-      <div class="c-top">
-        <div class="c-text">${emoji} ${escapeHtml(c.text)}</div>
-        <div class="c-actions">
-          <button class="btn btn-ghost c-del" type="button" title="Delete">Delete</button>
-        </div>
-      </div>
-      <div class="c-comments-wrap">
-        <ul class="c-comments"></ul>
-        <form class="c-add"><input placeholder="Add a comment…" maxlength="160"></form>
-      </div>
-      `;
+      // Row content
+      const emoji = { divine:'👑', family:'🏠', self:'🌱', rrr:'📚', work:'💵' }[c.pillar] || '•';
+      li.innerHTML = `
+      <div class="c-top">
+        <div class="c-text">${emoji} ${escapeHtml(c.text)}</div>
+        <div class="c-actions">
+          <button class="btn btn-ghost c-del" type="button" title="Delete">Delete</button>
+        </div>
+      </div>
+      <div class="c-comments-wrap">
+        <ul class="c-comments"></ul>
+        <form class="c-add"><input placeholder="Add a comment…" maxlength="160"></form>
+      </div>
+      `;
 
-      // Wire comments
-      const commentsUl = li.querySelector('.c-comments');
-      const addForm = li.querySelector('.c-add');
-      renderCommentsFor(commentsUl, c.id);
-      mountCommentForm(addForm, c.id, ()=> renderCommentsFor(commentsUl, c.id));
+      // Wire comments
+      const commentsUl = li.querySelector('.c-comments');
+      const addForm = li.querySelector('.c-add');
+      renderCommentsFor(commentsUl, c.id);
+      mountCommentForm(addForm, c.id, ()=> renderCommentsFor(commentsUl, c.id));
 
       // Wire delete (PIN-gated)
       const delBtn = li.querySelector('.c-del');
       handleDelete(delBtn, c.id, renderList);
 
-      return li;
-    }
+      return li;
+    }
 
-    function renderList(){
-      list.innerHTML = '';
-      todayCrumbs().forEach(c=> list.appendChild(makeRow(c)));
-    }
+    function renderList(){
+      list.innerHTML = '';
+      todayCrumbs().forEach(c=> list.appendChild(makeRow(c)));
+    }
 
-    function escapeHtml(s){ return (s||'').replace(/[&<>"']/g, m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;', "'":'&#39;' }[m])); }
+    function escapeHtml(s){ return (s||'').replace(/[&<>"']/g, m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;', "'":'&#39;' }[m])); }
 
-    renderList();
-  </script>
+    renderList();
+  </script>
+  <link rel="stylesheet" href="./css/settings.css">
+  <script type="module" src="./js/settings.js"></script>
+  <script type="module">
+    // Wire settings button
+    document.getElementById('openSettings')?.addEventListener('click', ()=> window.openSettings && window.openSettings());
+  </script>
 </body>
 </html>

--- a/jonah-swirl/index.html
+++ b/jonah-swirl/index.html
@@ -74,9 +74,17 @@
         <span>🪶 Shoeday (1 crumb is enough)</span>
       </label>
       <button id="versePeek" class="btn btn-ghost" aria-label="Show today’s verse">✨ Verse</button>
+      <button id="openSettings" class="btn btn-ghost" type="button">⚙︎ Settings</button>
     </div>
   </footer>
 
   <script src="./js/landing.js" defer></script>
+  <link rel="stylesheet" href="./css/settings.css">
+  <script type="module" src="./js/settings.js"></script>
+  <script type="module">
+    // Wire settings button
+    const btn = document.getElementById('openSettings');
+    btn?.addEventListener('click', ()=> window.openSettings && window.openSettings());
+  </script>
 </body>
 </html>

--- a/jonah-swirl/js/crumb-entry.js
+++ b/jonah-swirl/js/crumb-entry.js
@@ -1,50 +1,64 @@
 import { preselectPillarFromHash, saveCrumb, todayCrumbs } from './storage.js';
+import { compressFileToDataUrl } from './photos.js';
 
 (function(){
-  const form = document.getElementById('crumbForm');
-  const pillar = document.getElementById('pillar');
-  const text = document.getElementById('text');
-  const tags = document.getElementById('tags');
-  const todayUl = document.getElementById('todayUl');
+  const form = document.getElementById('crumbForm');
+  const pillar = document.getElementById('pillar');
+  const text = document.getElementById('text');
+  const tags = document.getElementById('tags');
+  const photo = document.getElementById('photo');
+  const todayUl = document.getElementById('todayUl');
 
-  // Preselect pillar from URL hash (e.g., day.html#self)
-  if (pillar) preselectPillarFromHash(pillar);
+  if (pillar) preselectPillarFromHash(pillar);
 
-  // Submit handler
-  form.addEventListener('submit', (e)=>{
-    e.preventDefault();
-    if(!pillar.value || !text.value.trim()) return;
+  form.addEventListener('submit', async (e)=>{
+    e.preventDefault();
+    if(!pillar.value || !text.value.trim()) return;
 
-    const crumb = saveCrumb({
-      pillar: pillar.value,
-      text: text.value.trim(),
-      tags: tags.value.trim()
-    });
+    let media = [];
+    const file = photo?.files?.[0];
+    if(file){
+      try{
+        const { dataUrl, width, height } = await compressFileToDataUrl(file, { max: 1024, quality: .72 });
+        media = [{ kind:'image', dataUrl, w: width, h: height }];
+      }catch(err){
+        console.warn('Photo compression failed, saving without image', err);
+      }
+    }
 
-    // Reset text, keep pillar for easy next crumb
-    text.value = ''; tags.value = '';
-    // Show in list
-    addToTodayList(crumb);
-  });
+    const crumb = saveCrumb({
+      pillar: pillar.value,
+      text: text.value.trim(),
+      tags: tags.value.trim(),
+      media
+    });
 
-  // Render today on load
-  renderToday();
+    // Reset text & photo, keep pillar for easy next crumb
+    text.value = ''; tags.value = ''; if(photo) photo.value = '';
+    addToTodayList(crumb);
+  });
 
-  function renderToday(){
-    todayUl.innerHTML = '';
-    todayCrumbs().forEach(addToTodayList);
-  }
+  renderToday();
 
-  function addToTodayList(c){
-    const li = document.createElement('li');
-    li.textContent = displayCrumb(c);
-    todayUl.prepend(li);
-  }
+  function renderToday(){
+    todayUl.innerHTML = '';
+    todayCrumbs().forEach(addToTodayList);
+  }
 
-  function displayCrumb(c){
-    const emoji = {
-      divine:'👑', family:'🏠', self:'🌱', rrr:'📚', work:'💵'
-    }[c.pillar] || '•';
-    return `${emoji} ${c.text}`;
-  }
+  function addToTodayList(c){
+    const li = document.createElement('li');
+    li.innerHTML = renderCrumbRow(c);
+    todayUl.prepend(li);
+  }
+
+  function renderCrumbRow(c){
+    const emoji = { divine:'👑', family:'🏠', self:'🌱', rrr:'📚', work:'💵' }[c.pillar] || '•';
+    const text = escapeHtml(c.text);
+    const img = (Array.isArray(c.media) && c.media[0]?.kind==='image')
+      ? `<div style="margin-top:6px;"><img alt="" src="${c.media[0].dataUrl}" style="max-width:100%; height:auto; border-radius:10px;"/></div>`
+      : '';
+    return `${emoji} ${text}${img}`;
+  }
+
+  function escapeHtml(s){ return (s||'').replace(/[&<>"']/g, m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;', "'":'&#39;' }[m])); }
 })();

--- a/jonah-swirl/js/photos.js
+++ b/jonah-swirl/js/photos.js
@@ -1,0 +1,40 @@
+// photos.js — gentle client-side image compression for Jonah
+// Usage:
+//   import { compressFileToDataUrl } from './photos.js';
+//   const { dataUrl, width, height } = await compressFileToDataUrl(file, { max:1024, quality:.72 });
+
+export async function compressFileToDataUrl(file, { max = 1024, quality = 0.72 } = {}){
+  if(!file || !file.type?.startsWith('image/')) throw new Error('Not an image');
+
+  const img = await fileToImage(file);
+  const { canvas, w, h } = fitCanvas(img, max);
+  const ctx = canvas.getContext('2d', { alpha: false });
+  ctx.drawImage(img, 0, 0, w, h);
+
+  const mime = 'image/jpeg'; // consistent export
+  const dataUrl = canvas.toDataURL(mime, quality);
+  return { dataUrl, width: w, height: h };
+}
+
+function fileToImage(file){
+  return new Promise((resolve, reject)=>{
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error('Read failed'));
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = () => reject(new Error('Image decode failed'));
+      img.src = reader.result;
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+function fitCanvas(img, max){
+  const ratio = Math.min(1, max / Math.max(img.naturalWidth, img.naturalHeight));
+  const w = Math.max(1, Math.round(img.naturalWidth * ratio));
+  const h = Math.max(1, Math.round(img.naturalHeight * ratio));
+  const canvas = document.createElement('canvas');
+  canvas.width = w; canvas.height = h;
+  return { canvas, w, h };
+}

--- a/jonah-swirl/js/settings.js
+++ b/jonah-swirl/js/settings.js
@@ -1,0 +1,132 @@
+// settings.js — one-page modal for PIN, Shoeday, and Cloud Sync
+// Neutral wireframe; depends on storage.js and sync.js
+
+import { settings, setSetting, pinExists, setPin } from './storage.js';
+import { initSync, config as syncConfig, setConfig as syncSetConfig, isEnabled as syncIsEnabled } from './sync.js';
+
+(function(){
+  initSync(); // start listening (no-ops if sync disabled)
+
+  function open(){
+    const s = settings();
+    const cfg = syncConfig();
+
+    const host = document.createElement('div');
+    host.className = 'settings-backdrop';
+    host.innerHTML = `
+      <section class="settings-modal">
+        <h2>Settings</h2>
+        <p class="hint">Manage Shoeday, Parent PIN, and optional Cloud Sync.</p>
+
+        <!-- Shoeday -->
+        <div class="settings-section">
+          <h3 style="margin:0 0 8px;">Shoeday</h3>
+          <div class="row">
+            <span class="lab">Enable</span>
+            <label class="switch">
+              <input id="setShoeday" type="checkbox">
+              <span>Collapse UI to “1 crumb + 1 verse.”</span>
+            </label>
+          </div>
+        </div>
+
+        <!-- Parent PIN -->
+        <div class="settings-section">
+          <h3 style="margin:0 0 8px;">Parent PIN</h3>
+          <div class="row">
+            <span class="lab">Status</span>
+            <div><span id="pinStatus">—</span></div>
+          </div>
+          <div id="pinSetBlock">
+            <div class="row">
+              <span class="lab">New PIN</span>
+              <input id="pinNew" type="password" inputmode="numeric" autocomplete="new-password" placeholder="Enter new PIN">
+            </div>
+            <div class="row">
+              <span class="lab">Confirm</span>
+              <input id="pinNew2" type="password" inputmode="numeric" autocomplete="new-password" placeholder="Repeat new PIN">
+            </div>
+            <div class="row" id="pinCurRow" style="display:none;">
+              <span class="lab">Current</span>
+              <input id="pinCurrent" type="password" inputmode="numeric" autocomplete="current-password" placeholder="Current PIN">
+            </div>
+          </div>
+        </div>
+
+        <!-- Cloud Sync (optional) -->
+        <div class="settings-section">
+          <h3 style="margin:0 0 8px;">Cloud Sync (optional)</h3>
+          <div class="row">
+            <span class="lab">Enable</span>
+            <label class="switch">
+              <input id="syncEnabled" type="checkbox">
+              <span>Send changes to your endpoint</span>
+            </label>
+          </div>
+          <div class="row">
+            <span class="lab">Endpoint URL</span>
+            <input id="syncEndpoint" type="text" placeholder="https://example.com">
+          </div>
+          <div class="row">
+            <span class="lab">Bearer Token</span>
+            <input id="syncToken" type="password" placeholder="optional">
+          </div>
+          <p class="hint">POST {endpoint}/api/ingest {events:[…]}, GET {endpoint}/api/snapshot for pulls.</p>
+        </div>
+
+        <div class="settings-actions">
+          <button id="btnSave" class="btn" type="button">Save</button>
+          <button id="btnClose" class="btn btn-ghost" type="button">Close</button>
+        </div>
+        <p id="msg" class="hint" role="status" aria-live="polite"></p>
+      </section>
+    `;
+
+    document.body.appendChild(host);
+
+    // Populate values
+    document.getElementById('setShoeday').checked = (s.shoeday === '1');
+    document.getElementById('pinStatus').textContent = pinExists() ? 'Set' : 'Not set';
+    document.getElementById('pinCurRow').style.display = pinExists() ? '' : 'none';
+
+    document.getElementById('syncEnabled').checked = (cfg.syncEnabled === '1') && !!(cfg.syncEndpoint||'').trim();
+    document.getElementById('syncEndpoint').value = cfg.syncEndpoint || '';
+    document.getElementById('syncToken').value = cfg.syncToken || '';
+
+    // Wire actions
+    document.getElementById('btnClose').addEventListener('click', ()=> host.remove());
+    document.getElementById('btnSave').addEventListener('click', ()=> onSave(host));
+  }
+
+  async function onSave(host){
+    const msg = host.querySelector('#msg');
+
+    // Shoeday
+    const shoedayOn = host.querySelector('#setShoeday').checked;
+    setSetting('shoeday', shoedayOn ? '1' : '0');
+    // Keep Jonah landing toggle in sync with old key used by landing.js
+    try{ localStorage.setItem('jonah_shoeday', shoedayOn ? '1' : '0'); }catch{}
+
+    // PIN set/change
+    const new1 = host.querySelector('#pinNew').value.trim();
+    const new2 = host.querySelector('#pinNew2').value.trim();
+    const cur  = host.querySelector('#pinCurrent').value.trim();
+    if(new1 || new2){
+      if(new1 !== new2){ msg.textContent = 'PINs must match.'; return; }
+      const res = setPin(new1, cur);
+      if(!res.ok){ msg.textContent = 'Current PIN incorrect.'; return; }
+    }
+
+    // Sync
+    const enabled  = host.querySelector('#syncEnabled').checked;
+    const endpoint = host.querySelector('#syncEndpoint').value.trim();
+    const token    = host.querySelector('#syncToken').value.trim();
+    syncSetConfig({ endpoint, token, enabled });
+
+    msg.textContent = 'Saved.';
+    setTimeout(()=>{ host.remove(); }, 400);
+  }
+
+  // Attach launcher to window so pages can open the modal
+  window.openSettings = open;
+})();

--- a/jonah-swirl/js/storage.js
+++ b/jonah-swirl/js/storage.js
@@ -1,115 +1,126 @@
-// Simple local storage layer for Jonah (Phase 1: local-first)
+// storage.js — local-first store + tiny event bus for sync
 // Namespaced keys so Mom's hub won't clash.
+
 const KEYS = {
-  crumbs: 'swirl_crumbs_jonah',
-  comments: 'swirl_comments_jonah',
-  settings: 'swirl_settings_jonah',
-  audit: 'swirl_audit_jonah'
+  crumbs:   'swirl_crumbs_jonah',
+  comments: 'swirl_comments_jonah',
+  settings: 'swirl_settings_jonah',
+  audit:    'swirl_audit_jonah'
 };
 
-const Storage = {
-  _load(key, fallback = '[]'){ try{ return JSON.parse(localStorage.getItem(key) || fallback); }catch{ return JSON.parse(fallback); } },
-  _save(key, val){ localStorage.setItem(key, JSON.stringify(val)); },
-
-  // --- Crumbs ---
-  getCrumbs(){ return this._load(KEYS.crumbs); },
-  addCrumb(crumb){
-    const list = this.getCrumbs(); list.push(crumb);
-    this._save(KEYS.crumbs, list);
-    this.audit('create','crumb', crumb.id, {pillar:crumb.pillar, text:crumb.text.slice(0,80)});
-    return crumb;
-  },
-  deleteCrumbById(id){
-    const list = this.getCrumbs();
-    const idx = list.findIndex(c=>c.id===id);
-    if(idx>=0){
-      const removed = list.splice(idx,1)[0];
-      this._save(KEYS.crumbs, list);
-      this.audit('delete','crumb', id, {pillar:removed?.pillar});
-      return true;
-    }
-    return false;
-  },
-
-  // --- Comments ---
-  getComments(){ return this._load(KEYS.comments); },
-  getCommentsFor(crumbId){ return this.getComments().filter(c=>c.crumbId===crumbId); },
-  addComment(c){
-    const list = this.getComments(); list.push(c);
-    this._save(KEYS.comments, list);
-    this.audit('create','comment', c.id, {crumbId:c.crumbId, author:c.author});
-    return c;
-  },
-
-  // --- Settings (PIN + Shoeday) ---
-  settings(){
-    return this._load(KEYS.settings, '{"shoeday":"0","pin":""}');
-  },
-  setSetting(name, value){
-    const s = this.settings(); s[name] = value;
-    localStorage.setItem(KEYS.settings, JSON.stringify(s));
-  },
-  pinExists(){ return !!(this.settings().pin || '').trim(); },
-  verifyPin(input){
-    const set = (this.settings().pin || '').trim();
-    const ok = set === (input || '').trim();
-    this.audit(ok?'pin_ok':'pin_fail','pin','settings',{});
-    return ok;
-  },
-  setPin(newPin, currentPin = ''){
-    const s = this.settings();
-    // If a PIN exists, require the current one to match
-    if ((s.pin || '').trim()){
-      if ((s.pin || '').trim() !== (currentPin || '').trim()){
-        this.audit('pin_fail','pin','settings',{reason:'bad_current'});
-        return {ok:false, reason:'bad_current'};
-      }
-    }
-    s.pin = (newPin || '').trim();
-    localStorage.setItem(KEYS.settings, JSON.stringify(s));
-    this.audit('pin_set','pin','settings',{});
-    return {ok:true};
-  },
-
-  // --- Audit ---
-  audit(action, targetType, targetId, diff){
-    const a = this._load(KEYS.audit);
-    a.push({ tsISO:new Date().toISOString(), actor:'jonah', action, targetType, targetId, diff });
-    this._save(KEYS.audit, a);
-  }
-};
-
-// Helpers used by pages
-export function preselectPillarFromHash(selectEl){
-  const h = (location.hash || '').replace('#','').trim();
-  if(!h) return;
-  const opt = [...selectEl.options].find(o=>o.value===h);
-  if(opt) selectEl.value = h;
+// Emit helper (so sync.js can listen)
+function emit(type, payload){
+  try{ window.dispatchEvent(new CustomEvent('swirl:changed', { detail: { type, ...payload } })); }
+  catch(e){ /* ignore */ }
 }
 
-export function saveCrumb({pillar, text, tags}){
-  const id = 'c_' + Math.random().toString(36).slice(2,9);
-  const crumb = {
-    id, tsISO: new Date().toISOString(),
-    pillar, text,
-    parts: [], skills: [],
-    media: [], tags: (tags||'').split(',').map(s=>s.trim()).filter(Boolean),
-    privacy:'private', status:'pending_review'
-  };
-  return Storage.addCrumb(crumb);
+const Storage = {
+  _load(key, fallback = '[]'){ try{ return JSON.parse(localStorage.getItem(key) || fallback); }catch{ return JSON.parse(fallback); } },
+  _save(key, val){ localStorage.setItem(key, JSON.stringify(val)); },
+
+  // --- Crumbs ---
+  getCrumbs(){ return this._load(KEYS.crumbs); },
+  addCrumb(crumb){
+    const list = this.getCrumbs(); list.push(crumb);
+    this._save(KEYS.crumbs, list);
+    this.audit('create','crumb', crumb.id, {pillar:crumb.pillar, text:crumb.text.slice(0,80)});
+    emit('crumb_create', { id: crumb.id, crumb });
+    return crumb;
+  },
+  deleteCrumbById(id){
+    const list = this.getCrumbs();
+    const idx = list.findIndex(c=>c.id===id);
+    if(idx>=0){
+      const removed = list.splice(idx,1)[0];
+      this._save(KEYS.crumbs, list);
+      this.audit('delete','crumb', id, {pillar:removed?.pillar});
+      emit('crumb_delete', { id });
+      return true;
+    }
+    return false;
+  },
+
+  // --- Comments ---
+  getComments(){ return this._load(KEYS.comments); },
+  getCommentsFor(crumbId){ return this.getComments().filter(c=>c.crumbId===crumbId); },
+  addComment(c){
+    const list = this.getComments(); list.push(c);
+    this._save(KEYS.comments, list);
+    this.audit('create','comment', c.id, {crumbId:c.crumbId, author:c.author});
+    emit('comment_create', { id: c.id, comment: c });
+    return c;
+  },
+
+  // --- Settings (PIN + Shoeday + Sync) ---
+  settings(){
+    return this._load(KEYS.settings, '{"shoeday":"0","pin":"","syncEnabled":"0","syncEndpoint":"","syncToken":""}');
+  },
+  setSetting(name, value){
+    const s = this.settings(); s[name] = value;
+    localStorage.setItem(KEYS.settings, JSON.stringify(s));
+    emit('settings_change', { name, value });
+  },
+  pinExists(){ return !!(this.settings().pin || '').trim(); },
+  verifyPin(input){
+    const set = (this.settings().pin || '').trim();
+    const ok = set === (input || '').trim();
+    this.audit(ok?'pin_ok':'pin_fail','pin','settings',{});
+    return ok;
+  },
+  setPin(newPin, currentPin = ''){
+    const s = this.settings();
+    if ((s.pin || '').trim()){
+      if ((s.pin || '').trim() !== (currentPin || '').trim()){
+        this.audit('pin_fail','pin','settings',{reason:'bad_current'});
+        return {ok:false, reason:'bad_current'};
+      }
+    }
+    s.pin = (newPin || '').trim();
+    localStorage.setItem(KEYS.settings, JSON.stringify(s));
+    this.audit('pin_set','pin','settings',{});
+    emit('pin_set', {});
+    return {ok:true};
+  },
+
+  // --- Audit ---
+  audit(action, targetType, targetId, diff){
+    const a = this._load(KEYS.audit);
+    a.push({ tsISO:new Date().toISOString(), actor:'jonah', action, targetType, targetId, diff });
+    this._save(KEYS.audit, a);
+  }
+};
+
+// Public API
+export function preselectPillarFromHash(selectEl){
+  const h = (location.hash || '').replace('#','').trim();
+  if(!h) return;
+  const opt = [...selectEl.options].find(o=>o.value===h);
+  if(opt) selectEl.value = h;
+}
+
+export function saveCrumb({pillar, text, tags, media}){
+  const id = 'c_' + Math.random().toString(36).slice(2,9);
+  const crumb = {
+    id, tsISO: new Date().toISOString(),
+    pillar, text,
+    parts: [], skills: [],
+    media: Array.isArray(media) ? media : [], // <— accept compressed images
+    tags: (tags||'').split(',').map(s=>s.trim()).filter(Boolean),
+    privacy:'private', status:'pending_review'
+  };
+  return Storage.addCrumb(crumb);
 }
 
 export function todayCrumbs(){
-  const today = new Date().toISOString().slice(0,10);
-  return Storage.getCrumbs().filter(c=> (c.tsISO||'').slice(0,10) === today);
+  const today = new Date().toISOString().slice(0,10);
+  return Storage.getCrumbs().filter(c=> (c.tsISO||'').slice(0,10) === today);
 }
-
 export function listCrumbs(){ return Storage.getCrumbs().slice().sort((a,b)=> (b.tsISO||'').localeCompare(a.tsISO||'')); }
 export function deleteCrumb(id){ return Storage.deleteCrumbById(id); }
 
 export function addComment({crumbId, text}){
-  const id = 'm_' + Math.random().toString(36).slice(2,9);
-  return Storage.addComment({ id, tsISO:new Date().toISOString(), crumbId, author:'jonah', text: text.trim() });
+  const id = 'm_' + Math.random().toString(36).slice(2,9);
+  return Storage.addComment({ id, tsISO:new Date().toISOString(), crumbId, author:'jonah', text: text.trim() });
 }
 export function commentsFor(crumbId){ return Storage.getCommentsFor(crumbId); }
 
@@ -118,3 +129,12 @@ export function setSetting(name, value){ return Storage.setSetting(name,value); 
 export function pinExists(){ return Storage.pinExists(); }
 export function verifyPin(input){ return Storage.verifyPin(input); }
 export function setPin(newPin, currentPin){ return Storage.setPin(newPin, currentPin); }
+
+// Extra getters useful for full snapshot export/import later:
+export function _all(){ 
+  return {
+    crumbs: Storage.getCrumbs(),
+    comments: Storage.getComments(),
+    settings: Storage.settings()
+  };
+}

--- a/jonah-swirl/js/sync.js
+++ b/jonah-swirl/js/sync.js
@@ -1,0 +1,87 @@
+// sync.js — optional cloud sync (OFF by default)
+// Reads/writes settings in localStorage via storage.js helpers.
+// Endpoints (defaults, override in UI):
+//   POST  {endpoint}/api/ingest   with JSON {events:[...]}
+//   GET   {endpoint}/api/snapshot returns {crumbs:[], comments:[], settings:{}}
+
+import { settings, setSetting } from './storage.js';
+
+const EVT = 'swirl:changed'; // emitted by storage.js after mutations
+let queue = [];       // buffered change events
+let flushing = false; // prevent concurrent flushes
+
+export function initSync(){
+  window.addEventListener(EVT, (e)=>{
+    queue.push(e.detail || {});
+    tryFlush();
+  });
+}
+
+export function isEnabled(){
+  const s = settings();
+  return (s.syncEnabled === '1') && !!(s.syncEndpoint||'').trim();
+}
+
+export function config(){ return settings(); }
+
+export function setConfig({ endpoint, token, enabled }){
+  if (typeof endpoint === 'string') setSetting('syncEndpoint', endpoint.trim());
+  if (typeof token === 'string') setSetting('syncToken', token.trim());
+  if (typeof enabled !== 'undefined') setSetting('syncEnabled', enabled ? '1' : '0');
+}
+
+export async function tryFlush(){
+  if(!isEnabled()) { queue = []; return; }
+  if(flushing || queue.length===0) return;
+  flushing = true;
+
+  const events = queue.splice(0, queue.length);
+  try{
+    await postJson(url('/api/ingest'), { events });
+  }catch(err){
+    // Put events back so we don't lose them; try later
+    queue.unshift(...events);
+    console.warn('Sync failed, will retry later', err);
+  }finally{
+    flushing = false;
+  }
+}
+
+export async function pullSnapshot({ replace = true } = {}){
+  const snap = await getJson(url('/api/snapshot'));
+  if(!snap || typeof snap !== 'object') throw new Error('Bad snapshot');
+  // In Phase 1 we don't auto-merge; we just return it to caller to decide.
+  return snap;
+}
+
+// Small helper to compose endpoint URL
+function url(path){
+  const s = settings();
+  const root = (s.syncEndpoint||'').replace(/\/+$/,'');
+  return root + path;
+}
+
+async function postJson(u, body){
+  const { syncToken } = settings();
+  const res = await fetch(u, {
+    method:'POST',
+    headers: {
+      'Content-Type':'application/json',
+      ...(syncToken ? { 'Authorization': `Bearer ${syncToken}` } : {})
+    },
+    body: JSON.stringify(body)
+  });
+  if(!res.ok) throw new Error(`POST ${u} -> ${res.status}`);
+  return res.json().catch(()=> ({}));
+}
+
+async function getJson(u){
+  const { syncToken } = settings();
+  const res = await fetch(u, {
+    headers: {
+      ...(syncToken ? { 'Authorization': `Bearer ${syncToken}` } : {})
+    }
+  });
+  if(!res.ok) throw new Error(`GET ${u} -> ${res.status}`);
+  return res.json();
+}

--- a/jonah-swirl/weekly.html
+++ b/jonah-swirl/weekly.html
@@ -10,15 +10,16 @@
 </head>
 <body>
   <main class="wrap">
-    <header class="head">
-      <a class="btn btn-ghost" href="./index.html">← Home</a>
-      <h1>Weekly Glow</h1>
-      <div class="head-actions">
-        <button id="prevWeek" class="btn btn-ghost" type="button">◀︎ Prev</button>
-        <button id="thisWeek" class="btn btn-ghost" type="button">This Week</button>
-        <button id="nextWeek" class="btn btn-ghost" type="button">Next ▶︎</button>
-      </div>
-    </header>
+    <header class="head">
+      <a class="btn btn-ghost" href="./index.html">← Home</a>
+      <h1>Weekly Glow</h1>
+      <div class="head-actions">
+        <button id="prevWeek" class="btn btn-ghost" type="button">◀︎ Prev</button>
+        <button id="thisWeek" class="btn btn-ghost" type="button">This Week</button>
+        <button id="nextWeek" class="btn btn-ghost" type="button">Next ▶︎</button>
+        <button id="openSettings" class="btn btn-ghost" type="button">⚙︎ Settings</button>
+      </div>
+    </header>
 
     <section class="week-range card" aria-live="polite">
       <h2 id="weekLabel">Week</h2>
@@ -49,15 +50,17 @@
     </section>
   </main>
 
-  <script type="module" src="./js/storage.js"></script>
-  <script type="module" src="./js/blooms.js"></script>
-  <script type="module" src="./js/export.js"></script>
-  <script type="module">
-    import { weekWindow, summarizeWeek, renderPillarBars, renderBlooms, gotoWeek, isoLabel } from './js/blooms.js';
-    import { downloadJson, downloadCsv } from './js/export.js';
+  <script type="module" src="./js/storage.js"></script>
+  <script type="module" src="./js/blooms.js"></script>
+  <script type="module" src="./js/export.js"></script>
+  <script type="module" src="./js/settings.js"></script>
+  <link rel="stylesheet" href="./css/settings.css">
+  <script type="module">
+    import { weekWindow, summarizeWeek, renderPillarBars, renderBlooms, gotoWeek, isoLabel } from './js/blooms.js';
+    import { downloadJson, downloadCsv } from './js/export.js';
 
-    // State: weekOffset = 0 -> this week; -1 prev; +1 next, etc.
-    let weekOffset = 0;
+    // State: weekOffset = 0 -> this week; -1 prev; +1 next, etc.
+    let weekOffset = 0;
 
     const weekLabel = document.getElementById('weekLabel');
     const bars = document.getElementById('pillarBars');
@@ -66,25 +69,26 @@
     const nextBtn = document.getElementById('nextWeek');
     const thisBtn = document.getElementById('thisWeek');
     const btnJson = document.getElementById('btnJson');
-    const btnCsv  = document.getElementById('btnCsv');
+    const btnCsv  = document.getElementById('btnCsv');
+    document.getElementById('openSettings')?.addEventListener('click', ()=> window.openSettings && window.openSettings());
 
-    function render(){
-      const { start, end } = weekWindow(weekOffset);
-      const summary = summarizeWeek(start, end);
-      weekLabel.textContent = `Week: ${isoLabel(start)} – ${isoLabel(end)}`;
-      renderPillarBars(bars, summary.pillars);
-      renderBlooms(bloomGrid, summary.tags);
-      // export handlers depend on current summary
-      btnJson.onclick = ()=> downloadJson(summary, start, end);
-      btnCsv.onclick  = ()=> downloadCsv(summary, start, end);
-    }
+    function render(){
+      const { start, end } = weekWindow(weekOffset);
+      const summary = summarizeWeek(start, end);
+      weekLabel.textContent = `Week: ${isoLabel(start)} – ${isoLabel(end)}`;
+      renderPillarBars(bars, summary.pillars);
+      renderBlooms(bloomGrid, summary.tags);
+      // export handlers depend on current summary
+      btnJson.onclick = ()=> downloadJson(summary, start, end);
+      btnCsv.onclick  = ()=> downloadCsv(summary, start, end);
+    }
 
-    prevBtn.onclick = ()=>{ weekOffset -= 1; render(); };
-    nextBtn.onclick = ()=>{ weekOffset += 1; render(); };
-    thisBtn.onclick = ()=>{ weekOffset  = 0; render(); };
+    prevBtn.onclick = ()=>{ weekOffset -= 1; render(); };
+    nextBtn.onclick = ()=>{ weekOffset += 1; render(); };
+    thisBtn.onclick = ()=>{ weekOffset  = 0; render(); };
 
-    // initial
-    render();
-  </script>
+    // initial
+    render();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add client-side photo compression and preview to daily crumbs
- introduce optional cloud sync and storage event bus
- consolidate shoeday, PIN, and sync settings into new modal available across pages

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a8814558832eb6532ed3fc98f3ed