### PR TITLE
Link hub pillars to Swirlfeed

### DIFF
--- a/jonah-swirl/css/hub.css
+++ b/jonah-swirl/css/hub.css
@@ -193,7 +193,7 @@ body{
   to   { transform: rotate(calc(var(--angle, 0deg) + 360deg)) translate(var(--radius, 160px)) rotate(calc(var(--angle, 0deg) * -1 - 360deg)); }
 }
 
-/* ~lines 222-260: modes + portal + a11y */
+/* ~lines 222-260: modes + a11y */
 body.mode-structured .token{
   animation-play-state: paused;
   /* snap into a quiet ring when Structured mode is on */
@@ -215,58 +215,7 @@ body.mode-structured #dropCrumb{ display:none; }
 }
 @keyframes twinkle{ 0%,100%{ opacity:0.25 } 50%{ opacity:0.7 } }
 
-dialog#portal{
-  border:0; padding:0; background:transparent;
-}
-.portal-card{
-  width:min(520px, 90vw);
-  margin:auto; padding:22px 20px;
-  background:rgba(255,255,255,0.75); backdrop-filter: blur(12px);
-  border-radius:18px; box-shadow: var(--glow-strong);
-}
-
-/* —— free-floating glimmers that drift up on open —— */
-.free-glimmer{
-  position:absolute; width:8px; height:8px; pointer-events:none;
-  background:
-    radial-gradient(circle, #fff 0 40%, transparent 41%),
-    radial-gradient(circle at 50% 50%, rgba(255,255,255,.95), transparent 60%);
-  border-radius:50%;
-  filter: drop-shadow(0 0 10px rgba(255,255,255,.8));
-  animation: floatout 2.4s ease-out forwards;
-  opacity:.9;
-}
-@keyframes floatout{
-  from { transform: translate(0,0) scale(.7); opacity:.9; }
-  to   { transform: translate(-8px,-36px) scale(1.2); opacity:0; }
-}
-
-/* —— POND RIPPLE OVERLAY (color-tinted to door hue) —— */
-.ripple-layer{
-  --rip-h: 0; --rip-s: 0%; --rip-l: 100%;
-  position: fixed;
-  left: calc(var(--x) * 1px);
-  top:  calc(var(--y) * 1px);
-  width: 22px; height: 22px;
-  transform: translate(-50%,-50%) scale(1);
-  border-radius: 50%;
-  background: radial-gradient(circle,
-      hsla(var(--rip-h), var(--rip-s), calc(var(--rip-l) + 10%), 0.55) 0%,
-      hsla(var(--rip-h), var(--rip-s), var(--rip-l), 0.35) 35%,
-      hsla(var(--rip-h), var(--rip-s), calc(var(--rip-l) - 10%), 0.12) 60%,
-      transparent 72%);
-  mix-blend-mode: soft-light;
-  pointer-events: none;
-  filter: blur(.4px);
-  animation: pond-ripple 1.8s ease-out forwards;
-  z-index: 5;
-}
-@keyframes pond-ripple{
-  to{ transform: translate(-50%,-50%) scale(28); opacity: 0; }
-}
-
 /* reduced motion kindness */
 @media (prefers-reduced-motion: reduce){
-  #pond::before, .swirl, .token, .sparkles,
-  .free-glimmer, .ripple-layer{ animation: none !important; }
+  #pond::before, .swirl, .token, .sparkles{ animation: none !important; }
 }

--- a/jonah-swirl/index.html
+++ b/jonah-swirl/index.html
@@ -55,15 +55,6 @@
     <div class="sparkles" aria-hidden="true"></div>
   </main>
 
-  <!-- SIMPLE PORTAL MODAL -->
-  <dialog id="portal">
-    <div class="portal-card">
-      <h2 id="portalTitle">Opening…</h2>
-      <p>This is a gentle placeholder portal. In the real build, this would load your tool.</p>
-      <button id="closePortal" class="pill">Close</button>
-    </div>
-  </dialog>
-
   <script src="js/hub.js"></script>
 </body>
 </html>

--- a/jonah-swirl/js/hub.js
+++ b/jonah-swirl/js/hub.js
@@ -2,7 +2,6 @@
 
 // ~lines 1-18: helpers + token setup
 const tokens = Array.from(document.querySelectorAll('.token'));
-const pond   = document.getElementById('pond');
 
 function rand(min, max){ return Math.random() * (max - min) + min; }
 
@@ -17,60 +16,14 @@ tokens.forEach((t, i) => {
   t.style.animationDuration = `${duration}s`;
 });
 
-// ~lines 20-78: click → door + portal
-const portal = document.getElementById('portal');
-const portalTitle = document.getElementById('portalTitle');
-const closePortal = document.getElementById('closePortal');
-
+// ~lines 20-40: click → navigate to pillar feed
 tokens.forEach((t) => {
-  t.addEventListener('click', (e) => {
-    const alreadyDoor = t.classList.contains('door');
-    // clear doors on others
-    tokens.forEach(x => { if(x !== t) x.classList.remove('door'); });
-
-    if(!alreadyDoor){
-      t.classList.add('door');
-      t.focus({preventScroll:true});
-      // emit free-floating glimmers
-      for(let i=0; i<3; i++){
-        const g = document.createElement('div');
-        g.className = 'free-glimmer';
-        g.style.left = (e.clientX + rand(-8,8)) + 'px';
-        g.style.top  = (e.clientY + rand(-8,8)) + 'px';
-        pond.appendChild(g);
-        setTimeout(()=> g.remove(), 2400);
-      }
-      // ripple from click point with door color
-      const hue = t.style.getPropertyValue('--hue').trim() || '0';
-      const sat = t.style.getPropertyValue('--sat').trim() || '0%';
-      const lit = t.style.getPropertyValue('--lit').trim() || '60%';
-      const r = document.createElement('div');
-      r.className = 'ripple-layer';
-      r.style.setProperty('--x', e.clientX);
-      r.style.setProperty('--y', e.clientY);
-      r.style.setProperty('--rip-h', hue);
-      r.style.setProperty('--rip-s', sat);
-      r.style.setProperty('--rip-l', lit);
-      document.body.appendChild(r);
-      setTimeout(()=> r.remove(), 1800);
-
-      // small pause then open portal
-      setTimeout(() => {
-        portalTitle.textContent = `Opening ${t.dataset.app}…`;
-        portal.showModal();
-      }, 220);
-    }else{
-      portalTitle.textContent = `Opening ${t.dataset.app}…`;
-      portal.showModal();
+  t.addEventListener('click', () => {
+    const pillar = t.dataset.pillar;
+    if(pillar){
+      location.href = `./swirlfeed.html#${pillar}`;
     }
   });
-});
-
-closePortal.addEventListener('click', () => portal.close());
-
-// close modal on Esc
-document.addEventListener('keydown', (e) => {
-  if(e.key === 'Escape' && portal.open) portal.close();
 });
 
 // ~lines 80-150: mode toggles (Swirlface ↔ Structured) + crumb capture
@@ -99,8 +52,7 @@ btnStructured.addEventListener('click', () => setMode('structured'));
 dropCrumb.addEventListener('click', () => {
   const text = prompt('Drop a crumb:');
   if(text && text.trim()){
-    portalTitle.textContent = 'Crumb saved and auto-sorted!';
-    portal.showModal();
+    alert('Crumb saved and auto-sorted!');
   }
 });
 

--- a/jonah-swirl/js/swirlfeed.js
+++ b/jonah-swirl/js/swirlfeed.js
@@ -18,6 +18,17 @@ const PILL_LABEL = {
   work:   '💵 Work'
 };
 
+// preselect pillar from URL hash if provided
+const hashPill = (location.hash || '').replace('#','').trim();
+if(hashPill && PILL_LABEL[hashPill]){
+  currentPill = hashPill;
+  chipRow.querySelectorAll('.chip').forEach(c => {
+    const active = c.dataset.pill === currentPill;
+    c.classList.toggle('is-active', active);
+    c.setAttribute('aria-selected', active ? 'true' : 'false');
+  });
+}
+
 function dateOnly(iso){ return (iso||'').slice(0,10); }
 function emojiFor(p){ return ({divine:'👑', family:'🏠', self:'🌱', rrr:'📚', work:'💵'})[p] || '•'; }
 


### PR DESCRIPTION
## Summary
- Remove placeholder portal and related styles from Jonah's hub
- Navigate to Swirlfeed when a pillar token is clicked
- Preselect pillar filter on Swirlfeed via URL hash

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b89561bc832eb5128ba9e6c79f0b