### PR TITLE
Add seasonal age styling for crumbs

### DIFF
--- a/jonah-swirl/css/base.css
+++ b/jonah-swirl/css/base.css
@@ -8,6 +8,13 @@
   --accent2: #FF9DD8;   /* Lucy pink sparkle */
   --accent3: #F0BC06;   /* golden encouragement */
 
+  /* Seasonal age bars */
+  --season-fresh:  #3c8a3c;
+  --season-spring: var(--accent1);
+  --season-summer: #d6a33a;
+  --season-fall:   #c3743a;
+  --season-winter: #6b7a8c;
+
   --shadow: rgba(0,0,0,0.12);
   --radius: 18px;
 
@@ -51,3 +58,18 @@ body{
   position:absolute!important; width:1px; height:1px; margin:-1px;
   overflow:hidden; clip:rect(0 0 0 0); white-space:nowrap; border:0;
 }
+
+/* Seasonal age bar for crumbs */
+.crumb-age{ position:relative; }
+.crumb-age::before{
+  content:'';
+  position:absolute;
+  left:0; top:0;
+  width:6px; height:100%;
+  border-radius:6px 0 0 6px;
+}
+.crumb-age.age-fresh::before{ background:var(--season-fresh); }
+.crumb-age.age-spring::before{ background:var(--season-spring); }
+.crumb-age.age-summer::before{ background:var(--season-summer); }
+.crumb-age.age-fall::before{ background:var(--season-fall); }
+.crumb-age.age-winter::before{ background:var(--season-winter); }

--- a/jonah-swirl/day.html
+++ b/jonah-swirl/day.html
@@ -69,6 +69,7 @@
   <script type="module">
     import { todayCrumbs } from './js/storage.js';
     import { renderCommentsFor, mountCommentForm, handleDelete } from './js/comments.js';
+    import { seasonClass } from './js/season.js';
 
     const list = document.getElementById('todayUl');
     const parentBtn = document.getElementById('parentBtn');
@@ -81,6 +82,7 @@
     function makeRow(c){
       const li = document.createElement('li');
       li.dataset.id = c.id;
+      li.className = 'crumb-age ' + seasonClass(c.tsISO);
 
       // Row content
       const emoji = { divine:'👑', family:'🏠', self:'🌱', rrr:'📚', work:'💵' }[c.pillar] || '•';

--- a/jonah-swirl/js/crumb-entry.js
+++ b/jonah-swirl/js/crumb-entry.js
@@ -1,5 +1,6 @@
 import { preselectPillarFromHash, saveCrumb, todayCrumbs } from './storage.js';
 import { compressFileToDataUrl } from './photos.js';
+import { seasonClass } from './season.js';
 
 (function(){
   const form = document.getElementById('crumbForm');
@@ -47,6 +48,7 @@ import { compressFileToDataUrl } from './photos.js';
 
   function addToTodayList(c){
     const li = document.createElement('li');
+    li.className = 'crumb-age ' + seasonClass(c.tsISO);
     li.innerHTML = renderCrumbRow(c);
     todayUl.prepend(li);
   }

--- a/jonah-swirl/js/season.js
+++ b/jonah-swirl/js/season.js
@@ -1,0 +1,20 @@
+export function seasonClass(tsISO){
+  const ts = new Date(tsISO).getTime();
+  const days = (Date.now() - ts) / 86400000;
+  if (days <= 14) return 'age-fresh';
+  if (days <= 44) return 'age-spring';
+  if (days <= 104) return 'age-summer';
+  if (days <= 224) return 'age-fall';
+  return 'age-winter';
+}
+
+export function seasonLabel(tsISO){
+  const cls = seasonClass(tsISO);
+  return {
+    'age-fresh': 'Fresh',
+    'age-spring': 'Spring',
+    'age-summer': 'Summer',
+    'age-fall': 'Fall',
+    'age-winter': 'Winter'
+  }[cls] || 'Fresh';
+}

--- a/jonah-swirl/js/swirlfeed.js
+++ b/jonah-swirl/js/swirlfeed.js
@@ -2,6 +2,7 @@
 // Uses listCrumbs() from storage.js
 
 import { listCrumbs } from './storage.js';
+import { seasonClass } from './season.js';
 
 const feedRoot = document.getElementById('feedRoot');
 const chipRow  = document.querySelector('.chips');
@@ -65,8 +66,8 @@ function groupByDay(rows){
 function escapeHtml(s){ return (s||'').replace(/[&<>"']/g, m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;', "'":'&#39;' }[m])); }
 
 function makeItem(c){
-  const div = document.createElement('div');
-  div.className = 'item';
+  const div = document.createElement('div');
+  div.className = 'item crumb-age ' + seasonClass(c.tsISO);
   div.innerHTML = `
     <div class="txt">${emojiFor(c.pillar)} ${escapeHtml(c.text)}</div>
     <div class="pill">${PILL_LABEL[c.pillar]||''}</div>
@@ -107,14 +108,18 @@ function render(){
 
 // chip interactions
 chipRow.addEventListener('click', (e)=>{
-  const btn = e.target.closest('.chip');
-  if(!btn) return;
-  const pill = btn.dataset.pill;
-  if(!pill) return;
-  currentPill = pill;
-  // update active
-  chipRow.querySelectorAll('.chip').forEach(c=> c.classList.toggle('is-active', c===btn));
-  render();
+  const btn = e.target.closest('.chip');
+  if(!btn) return;
+  const pill = btn.dataset.pill;
+  if(!pill) return;
+  currentPill = pill;
+  // update active + aria-selected
+  chipRow.querySelectorAll('.chip').forEach(c=>{
+    const active = c === btn;
+    c.classList.toggle('is-active', active);
+    c.setAttribute('aria-selected', active ? 'true' : 'false');
+  });
+  render();
 });
 
 // search interactions (debounced)


### PR DESCRIPTION
## Summary
- color-code crumbs by age using seasonal bar styles
- share season utilities across day and feed pages
- expose seasonal colors via tokens and update feed chip aria-state

## Testing
- `node --check jonah-swirl/js/crumb-entry.js`
- `node --check jonah-swirl/js/swirlfeed.js`
- `node --check jonah-swirl/js/season.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5c92c79a4832e8f97ec4988620707