### PR TITLE
Add schedule and narrative with media support

### DIFF
--- a/jonah-swirl/css/swirlfeed.css
+++ b/jonah-swirl/css/swirlfeed.css
@@ -69,3 +69,7 @@ body { margin:0; background: var(--bg); color: var(--ink); }
   background: rgba(255,255,255,.8); cursor:pointer;
 }
 .item .go:hover{ box-shadow: 0 0 0 3px rgba(143,213,196,.25); }
+
+.cover{ cursor:pointer; }
+.cover img{ display:block; width:100%; height:auto; }
+.day-details.hidden{ display:none; }

--- a/jonah-swirl/day.html
+++ b/jonah-swirl/day.html
@@ -11,11 +11,16 @@
   <!-- DAY VIEW / ENTRY -->
   <!-- QUOTE ROTATOR / VERSE PREVIEW (future) -->
 
-  <main class="day-wrap">
-    <header class="day-head">
-      <a class="btn btn-ghost" href="./index.html">← Home</a>
-      <h1>Drop a Crumb</h1>
-    </header>
+  <main class="day-wrap">
+    <header class="day-head">
+      <a class="btn btn-ghost" href="./index.html">← Home</a>
+      <h1>Drop a Crumb</h1>
+    </header>
+
+    <section id="schedule" class="card">
+      <h2>Today's Plan</h2>
+      <ul id="scheduleList"></ul>
+    </section>
 
     <form id="crumbForm" class="card">
       <label class="row">
@@ -35,8 +40,8 @@
       </label>
 
       <label class="row">
-        <span class="lab">Photo</span>
-        <input id="photo" type="file" accept="image/*" capture="environment">
+        <span class="lab">Add media</span>
+        <input id="photo" type="file" multiple>
       </label>
 
       <label class="row">
@@ -55,7 +60,12 @@
       </div>
       <ul id="todayUl" aria-live="polite"></ul>
     </section>
-  </main>
+
+    <section id="narrative" class="card">
+      <h2>Today's Story</h2>
+      <p id="narrativeText"></p>
+    </section>
+  </main>
 
   <script type="module" src="./js/storage.js"></script>
   <script type="module" src="./js/crumb-entry.js"></script>
@@ -73,10 +83,19 @@
 
     const list = document.getElementById('todayUl');
     const parentBtn = document.getElementById('parentBtn');
+    const narrativeText = document.getElementById('narrativeText');
+    const scheduleList = document.getElementById('scheduleList');
+    const PILL_EMOJI = { divine:'👑', family:'🏠', self:'🌱', rrr:'📚', work:'💵' };
 
     // Parent controls: set/change PIN
     parentBtn.addEventListener('click', ()=>{
       window.pinPrompt?.({ mode:'set', onOk(){ /* no-op; modal reports success */ } });
+    });
+
+    window.addEventListener('swirl:changed', e=>{
+      if(e.detail?.type === 'crumb_create' || e.detail?.type === 'crumb_delete'){
+        renderList();
+      }
     });
 
     function makeRow(c){
@@ -85,7 +104,7 @@
       li.className = 'crumb-age ' + seasonClass(c.tsISO);
 
       // Row content
-      const emoji = { divine:'👑', family:'🏠', self:'🌱', rrr:'📚', work:'💵' }[c.pillar] || '•';
+      const emoji = PILL_EMOJI[c.pillar] || '•';
       li.innerHTML = `
       <div class="c-top">
         <div class="c-text">${emoji} ${escapeHtml(c.text)}</div>
@@ -115,11 +134,35 @@
     function renderList(){
       list.innerHTML = '';
       todayCrumbs().forEach(c=> list.appendChild(makeRow(c)));
+      renderNarrative();
+    }
+
+    function renderNarrative(){
+      const crumbs = todayCrumbs();
+      narrativeText.textContent = crumbs.map(c=> c.text).join(' ');
+    }
+
+    function renderSchedule(){
+      scheduleList.innerHTML = '';
+      try{
+        const plan = JSON.parse(localStorage.getItem('swirl_plan_jonah') || '{}');
+        const cells = plan.cells || {};
+        const dow = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][new Date().getDay()];
+        Object.entries(cells).forEach(([key,val])=>{
+          const [pillar, day] = key.split('_');
+          if(day===dow && val){
+            const li = document.createElement('li');
+            li.textContent = `${PILL_EMOJI[pillar]||''} ${val}`;
+            scheduleList.appendChild(li);
+          }
+        });
+      }catch{}
     }
 
     function escapeHtml(s){ return (s||'').replace(/[&<>"']/g, m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;', "'":'&#39;' }[m])); }
 
     renderList();
+    renderSchedule();
   </script>
   <link rel="stylesheet" href="./css/settings.css">
   <script type="module" src="./js/settings.js"></script>

--- a/jonah-swirl/index.html
+++ b/jonah-swirl/index.html
@@ -18,6 +18,7 @@
       <button id="btnStructured" class="pill">Structured</button>
     </nav>
     <button id="dropCrumb" class="pill">Drop Crumb</button>
+    <a class="btn btn-ghost" href="./day.html">✍️ Enter Day</a>
     <a class="btn btn-ghost" href="./grandma-plan.html">🗒️ Plan (Upcoming)</a>
   </header>
 
@@ -41,7 +42,8 @@
                  a45,45 0 1,0 90,0
                  m-60,0
                  a60,60 0 1,0 120,0"
-              fill="none" stroke="currentColor" stroke-width="1.75" opacity="0.8"/>
+              fill="none" stroke="currentColor" stroke-width="1.75" opacity="0.8"
+              stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
     </div>
 

--- a/jonah-swirl/js/crumb-entry.js
+++ b/jonah-swirl/js/crumb-entry.js
@@ -1,6 +1,5 @@
-import { preselectPillarFromHash, saveCrumb, todayCrumbs } from './storage.js';
+import { preselectPillarFromHash, saveCrumb } from './storage.js';
 import { compressFileToDataUrl } from './photos.js';
-import { seasonClass } from './season.js';
 
 (function(){
   const form = document.getElementById('crumbForm');
@@ -8,7 +7,6 @@ import { seasonClass } from './season.js';
   const text = document.getElementById('text');
   const tags = document.getElementById('tags');
   const photo = document.getElementById('photo');
-  const todayUl = document.getElementById('todayUl');
 
   if (pillar) preselectPillarFromHash(pillar);
 
@@ -17,17 +15,27 @@ import { seasonClass } from './season.js';
     if(!pillar.value || !text.value.trim()) return;
 
     let media = [];
-    const file = photo?.files?.[0];
-    if(file){
-      try{
-        const { dataUrl, width, height } = await compressFileToDataUrl(file, { max: 1024, quality: .72 });
-        media = [{ kind:'image', dataUrl, w: width, h: height }];
-      }catch(err){
-        console.warn('Photo compression failed, saving without image', err);
+    if(photo?.files?.length){
+      for(const file of photo.files){
+        if(file.type.startsWith('image/')){
+          try{
+            const { dataUrl, width, height } = await compressFileToDataUrl(file, { max: 1024, quality: .72 });
+            media.push({ kind:'image', dataUrl, w: width, h: height, name: file.name });
+          }catch(err){
+            console.warn('Photo compression failed, skipping image', err);
+          }
+        }else{
+          try{
+            const dataUrl = await fileToDataUrl(file);
+            media.push({ kind:'file', dataUrl, name: file.name, type: file.type });
+          }catch(err){
+            console.warn('File read failed, skipping', err);
+          }
+        }
       }
     }
 
-    const crumb = saveCrumb({
+    saveCrumb({
       pillar: pillar.value,
       text: text.value.trim(),
       tags: tags.value.trim(),
@@ -36,31 +44,14 @@ import { seasonClass } from './season.js';
 
     // Reset text & photo, keep pillar for easy next crumb
     text.value = ''; tags.value = ''; if(photo) photo.value = '';
-    addToTodayList(crumb);
   });
 
-  renderToday();
-
-  function renderToday(){
-    todayUl.innerHTML = '';
-    todayCrumbs().forEach(addToTodayList);
+  function fileToDataUrl(file){
+    return new Promise((resolve, reject)=>{
+      const reader = new FileReader();
+      reader.onerror = ()=> reject(new Error('Read failed'));
+      reader.onload = ()=> resolve(reader.result);
+      reader.readAsDataURL(file);
+    });
   }
-
-  function addToTodayList(c){
-    const li = document.createElement('li');
-    li.className = 'crumb-age ' + seasonClass(c.tsISO);
-    li.innerHTML = renderCrumbRow(c);
-    todayUl.prepend(li);
-  }
-
-  function renderCrumbRow(c){
-    const emoji = { divine:'👑', family:'🏠', self:'🌱', rrr:'📚', work:'💵' }[c.pillar] || '•';
-    const text = escapeHtml(c.text);
-    const img = (Array.isArray(c.media) && c.media[0]?.kind==='image')
-      ? `<div style="margin-top:6px;"><img alt="" src="${c.media[0].dataUrl}" style="max-width:100%; height:auto; border-radius:10px;"/></div>`
-      : '';
-    return `${emoji} ${text}${img}`;
-  }
-
-  function escapeHtml(s){ return (s||'').replace(/[&<>"']/g, m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;', "'":'&#39;' }[m])); }
 })();

--- a/jonah-swirl/js/swirlfeed.js
+++ b/jonah-swirl/js/swirlfeed.js
@@ -79,11 +79,11 @@ function makeItem(c){
 }
 
 function render(){
-  const rows = filtered();
-  const groups = groupByDay(rows);
+  const rows = filtered();
+  const groups = groupByDay(rows);
 
-  feedRoot.innerHTML = '';
-  if(!groups.length){
+  feedRoot.innerHTML = '';
+  if(!groups.length){
     const p = document.createElement('p');
     p.className = 'hint';
     p.textContent = q || currentPill!=='all'
@@ -91,19 +91,47 @@ function render(){
       : 'No crumbs yet. Drop one from the Home doors or Day page.';
     feedRoot.appendChild(p);
     return;
-  }
+  }
 
-  for(const [day, items] of groups){
-    const group = document.createElement('div');
-    group.className = 'day-group';
-    const h = document.createElement('h3');
-    h.className = 'day-head';
-    h.textContent = day;
-    group.appendChild(h);
+  for(const [day, items] of groups){
+    const group = document.createElement('div');
+    group.className = 'day-group';
 
-    items.forEach(c=> group.appendChild(makeItem(c)));
-    feedRoot.appendChild(group);
-  }
+    const coverCrumb = items.find(c=> Array.isArray(c.media) && c.media.find(m=>m.kind==='image'));
+    if(coverCrumb){
+      const imgObj = coverCrumb.media.find(m=>m.kind==='image');
+      const cover = document.createElement('div');
+      cover.className = 'cover';
+      cover.innerHTML = `<img src="${imgObj.dataUrl}" alt="" />`;
+      group.appendChild(cover);
+
+      const details = document.createElement('div');
+      details.className = 'day-details hidden';
+      const h = document.createElement('h3');
+      h.className = 'day-head';
+      h.textContent = day;
+      details.appendChild(h);
+      const nar = document.createElement('p');
+      nar.className = 'narrative';
+      nar.textContent = items.map(c=> c.text).join(' ');
+      details.appendChild(nar);
+      items.forEach(c=> details.appendChild(makeItem(c)));
+      group.appendChild(details);
+      cover.addEventListener('click', ()=> details.classList.toggle('hidden'));
+    }else{
+      const h = document.createElement('h3');
+      h.className = 'day-head';
+      h.textContent = day;
+      group.appendChild(h);
+      const nar = document.createElement('p');
+      nar.className = 'narrative';
+      nar.textContent = items.map(c=> c.text).join(' ');
+      group.appendChild(nar);
+      items.forEach(c=> group.appendChild(makeItem(c)));
+    }
+
+    feedRoot.appendChild(group);
+  }
 }
 
 // chip interactions


### PR DESCRIPTION
## Summary
- Display today's plan and auto-generated story on the day page
- Allow multiple media attachments when saving crumbs
- Show each day's cover photo with expandable details in the feed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c640e79d70832e951ced870351ba9a