### PR TITLE
Add day navigation and schedule views

### DIFF
--- a/jonah-swirl/calendar.html
+++ b/jonah-swirl/calendar.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Jonah Schedule</title>
+  <link rel="stylesheet" href="./css/base.css">
+  <link rel="stylesheet" href="./css/grandma-plan.css">
+</head>
+<body>
+  <main class="wrap">
+    <header class="head no-print">
+      <a class="btn btn-ghost" href="./index.html">← Home</a>
+      <div class="spacer"></div>
+      <button id="btnPrint" class="btn" type="button">🖨 Print</button>
+    </header>
+
+    <section class="card">
+      <h1>Schedule</h1>
+      <div id="scheduleGrid" class="plan-grid" aria-label="Weekly schedule"></div>
+      <p id="noPlan" class="hint" style="display:none;">No schedule found. Create one in Plan page.</p>
+    </section>
+  </main>
+
+  <script type="module">
+    const plan = JSON.parse(localStorage.getItem('swirl_plan_jonah') || '{}');
+    const grid = document.getElementById('scheduleGrid');
+    const noPlan = document.getElementById('noPlan');
+    const PILLARS = ['divine','family','self','rrr','work'];
+    const DAYS = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
+    const EMOJI = { divine:'👑', family:'🏠', self:'🌱', rrr:'📚', work:'💵' };
+    function cell(cls, text){ const d=document.createElement('div'); d.className=cls; d.textContent=text; return d; }
+    function nameOf(p){ return ({divine:'Divine',family:'Home',self:'Self',rrr:'Skills',work:'Work'})[p] || p; }
+    grid.appendChild(cell('hdr','Pillar/Day'));
+    DAYS.forEach(d=> grid.appendChild(cell('hdr',d)));
+    PILLARS.forEach(p=>{
+      grid.appendChild(cell('phdr', `${EMOJI[p]} ${nameOf(p)}`));
+      DAYS.forEach(d=>{
+        const txt = (plan.cells||{})[`${p}_${d}`] || '';
+        grid.appendChild(cell('cell', txt));
+      });
+    });
+    if(!plan.cells || Object.keys(plan.cells).length===0){ noPlan.style.display='block'; }
+    document.getElementById('btnPrint').addEventListener('click', ()=> window.print());
+  </script>
+</body>
+</html>

--- a/jonah-swirl/day.html
+++ b/jonah-swirl/day.html
@@ -12,10 +12,15 @@
   <!-- QUOTE ROTATOR / VERSE PREVIEW (future) -->
 
   <main class="day-wrap">
-    <header class="day-head">
-      <a class="btn btn-ghost" href="./index.html">← Home</a>
-      <h1>Drop a Crumb</h1>
-    </header>
+    <header class="day-head">
+      <a class="btn btn-ghost" href="./index.html">← Home</a>
+      <h1>Drop a Crumb</h1>
+    </header>
+
+    <section id="daySchedule" class="card">
+      <h2>Today's Schedule</h2>
+      <ul id="scheduleList"></ul>
+    </section>
 
     <form id="crumbForm" class="card">
       <label class="row">
@@ -73,6 +78,7 @@
 
     const list = document.getElementById('todayUl');
     const parentBtn = document.getElementById('parentBtn');
+    const scheduleUl = document.getElementById('scheduleList');
 
     // Parent controls: set/change PIN
     parentBtn.addEventListener('click', ()=>{
@@ -117,9 +123,27 @@
       todayCrumbs().forEach(c=> list.appendChild(makeRow(c)));
     }
 
+    function renderSchedule(){
+      const plan = JSON.parse(localStorage.getItem('swirl_plan_jonah') || '{}');
+      const cells = plan.cells || {};
+      const dayNames = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+      const dayName = dayNames[new Date().getDay()];
+      const EMOJI = { divine:'👑', family:'🏠', self:'🌱', rrr:'📚', work:'💵' };
+      const items = [];
+      ['divine','family','self','rrr','work'].forEach(p=>{
+        const key = `${p}_${dayName}`;
+        if(cells[key]) items.push(`${EMOJI[p]||''} ${cells[key]}`);
+      });
+      const goals = JSON.parse(localStorage.getItem('swirl_goals_jonah') || '[]');
+      const todayISO = new Date().toISOString().slice(0,10);
+      goals.forEach(g=>{ if(g.date === todayISO){ items.push(`${EMOJI[g.pillar]||''} ${g.title}`); }});
+      scheduleUl.innerHTML = items.length ? items.map(t=>`<li>${escapeHtml(t)}</li>`).join('') : '<li>No scheduled activities.</li>';
+    }
+
     function escapeHtml(s){ return (s||'').replace(/[&<>"']/g, m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;', "'":'&#39;' }[m])); }
 
     renderList();
+    renderSchedule();
   </script>
   <link rel="stylesheet" href="./css/settings.css">
   <script type="module" src="./js/settings.js"></script>

--- a/jonah-swirl/index.html
+++ b/jonah-swirl/index.html
@@ -17,8 +17,9 @@
       <button id="btnSwirl" class="pill active" aria-pressed="true">Swirlface</button>
       <button id="btnStructured" class="pill">Structured</button>
     </nav>
-    <button id="dropCrumb" class="pill">Drop Crumb</button>
+    <a id="enterDay" class="pill" href="./day.html">Enter Day</a>
     <a class="btn btn-ghost" href="./grandma-plan.html">🗒️ Plan (Upcoming)</a>
+    <a class="btn btn-ghost" href="./calendar.html">📅 Schedule</a>
   </header>
 
   <!-- POND + SWIRL CENTER -->

--- a/jonah-swirl/js/hub.js
+++ b/jonah-swirl/js/hub.js
@@ -29,7 +29,6 @@ tokens.forEach((t) => {
 // ~lines 80-150: mode toggles (Swirlface ↔ Structured) + crumb capture
 const btnSwirl      = document.getElementById('btnSwirl');
 const btnStructured = document.getElementById('btnStructured');
-const dropCrumb     = document.getElementById('dropCrumb');
 
 function setMode(mode){
   document.body.classList.toggle('mode-swirl',      mode === 'swirl');
@@ -48,13 +47,6 @@ function setMode(mode){
 
 btnSwirl.addEventListener('click',      () => setMode('swirl'));
 btnStructured.addEventListener('click', () => setMode('structured'));
-
-dropCrumb.addEventListener('click', () => {
-  const text = prompt('Drop a crumb:');
-  if(text && text.trim()){
-    alert('Crumb saved and auto-sorted!');
-  }
-});
 
 // start in Swirlface mode
 setMode('swirl');


### PR DESCRIPTION
## Summary
- Add Enter Day button and Schedule link on Jonah's main page
- Show today's scheduled activities on the day entry page
- Introduce printable calendar view for Jonah's weekly schedule

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c644933a8c832eaf343a023cd90d4b