### PR TITLE
Add day navigation and schedule views

### DIFF
--- a/jonah-swirl/calendar.html
+++ b/jonah-swirl/calendar.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Jonah Schedule</title>
+  <link rel="stylesheet" href="./css/base.css">
+  <link rel="stylesheet" href="./css/grandma-plan.css">
+</head>
+<body>
+  <main class="wrap">
+    <header class="head no-print">
+      <a class="btn btn-ghost" href="./index.html">← Home</a>
+      <div class="spacer"></div>
+      <button id="btnPrint" class="btn" type="button">🖨 Print</button>
+    </header>
+
+    <section class="card">
+      <h1>Schedule</h1>
+      <div id="scheduleGrid" class="plan-grid" aria-label="Weekly schedule"></div>
+      <p id="noPlan" class="hint" style="display:none;">No schedule found. Create one in Plan page.</p>
+    </section>
+  </main>
+
+  <script type="module">
+    const plan = JSON.parse(localStorage.getItem('swirl_plan_jonah') || '{}');
+    const grid = document.getElementById('scheduleGrid');
+    const noPlan = document.getElementById('noPlan');
+    const PILLARS = ['divine','family','self','rrr','work'];
+    const DAYS = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
+    const EMOJI = { divine:'👑', family:'🏠', self:'🌱', rrr:'📚', work:'💵' };
+    function cell(cls, text){ const d=document.createElement('div'); d.className=cls; d.textContent=text; return d; }
+    function nameOf(p){ return ({divine:'Divine',family:'Home',self:'Self',rrr:'Skills',work:'Work'})[p] || p; }
+    grid.appendChild(cell('hdr','Pillar/Day'));
+    DAYS.forEach(d=> grid.appendChild(cell('hdr',d)));
+    PILLARS.forEach(p=>{
+      grid.appendChild(cell('phdr', `${EMOJI[p]} ${nameOf(p)}`));
+      DAYS.forEach(d=>{
+        const txt = (plan.cells||{})[`${p}_${d}`] || '';
+        grid.appendChild(cell('cell', txt));
+      });
+    });
+    if(!plan.cells || Object.keys(plan.cells).length===0){ noPlan.style.display='block'; }
+    document.getElementById('btnPrint').addEventListener('click', ()=> window.print());
+  </script>
+</body>
+</html>

--- a/jonah-swirl/css/hub.css
+++ b/jonah-swirl/css/hub.css
@@ -37,6 +37,7 @@ body{
   position:fixed; inset: 16px 16px auto 16px;
   display:flex; align-items:center; justify-content:space-between;
   gap:16px; padding:10px 12px;
+  flex-wrap:wrap;
   background:rgba(255,255,255,0.55); backdrop-filter: blur(8px);
   border-radius:14px; box-shadow: var(--glow);
   z-index: 10;
@@ -103,6 +104,15 @@ body{
 }
 @keyframes breathe{ 0%,100%{ transform:scale(1)} 50%{ transform:scale(1.03)} }
 .swirl-svg{ width:82%; height:82%; }
+
+/* Responsive tweaks */
+@media (max-width:600px){
+  .lab-toolbar{ justify-content:center; }
+  .lab-toolbar .brand{ flex-basis:100%; justify-content:center; }
+  .lab-toolbar .modes{ flex-basis:100%; justify-content:center; }
+  .lab-toolbar > a{ flex-basis:100%; text-align:center; }
+  .token{ --size:70px; }
+}
 
 /* ~lines 146-220: tokens (circles → doors) */
 .token{

--- a/jonah-swirl/day.html
+++ b/jonah-swirl/day.html
@@ -1,21 +1,26 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Drop a Crumb · Jonah</title>
-  <link rel="stylesheet" href="./css/base.css">
-  <link rel="stylesheet" href="./css/day.css">
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Drop a Crumb · Jonah</title>
+  <link rel="stylesheet" href="./css/base.css">
+  <link rel="stylesheet" href="./css/day.css">
 </head>
 <body>
-  <!-- DAY VIEW / ENTRY -->
-  <!-- QUOTE ROTATOR / VERSE PREVIEW (future) -->
+  <!-- DAY VIEW / ENTRY -->
+  <!-- QUOTE ROTATOR / VERSE PREVIEW (future) -->
 
-  <main class="day-wrap">
-    <header class="day-head">
-      <a class="btn btn-ghost" href="./index.html">← Home</a>
-      <h1>Drop a Crumb</h1>
-    </header>
+  <main class="day-wrap">
+    <header class="day-head">
+      <a class="btn btn-ghost" href="./index.html">← Home</a>
+      <h1>Drop a Crumb</h1>
+    </header>
+
+    <section id="daySchedule" class="card">
+      <h2>Today's Schedule</h2>
+      <ul id="scheduleList"></ul>
+    </section>
 
     <form id="crumbForm" class="card">
       <label class="row">
@@ -55,7 +60,7 @@
       </div>
       <ul id="todayUl" aria-live="polite"></ul>
     </section>
-  </main>
+  </main>
 
   <script type="module" src="./js/storage.js"></script>
   <script type="module" src="./js/crumb-entry.js"></script>
@@ -73,6 +78,7 @@
 
     const list = document.getElementById('todayUl');
     const parentBtn = document.getElementById('parentBtn');
+    const scheduleUl = document.getElementById('scheduleList');
 
     // Parent controls: set/change PIN
     parentBtn.addEventListener('click', ()=>{
@@ -117,9 +123,27 @@
       todayCrumbs().forEach(c=> list.appendChild(makeRow(c)));
     }
 
+    function renderSchedule(){
+      const plan = JSON.parse(localStorage.getItem('swirl_plan_jonah') || '{}');
+      const cells = plan.cells || {};
+      const dayNames = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+      const dayName = dayNames[new Date().getDay()];
+      const EMOJI = { divine:'👑', family:'🏠', self:'🌱', rrr:'📚', work:'💵' };
+      const items = [];
+      ['divine','family','self','rrr','work'].forEach(p=>{
+        const key = `${p}_${dayName}`;
+        if(cells[key]) items.push(`${EMOJI[p]||''} ${cells[key]}`);
+      });
+      const goals = JSON.parse(localStorage.getItem('swirl_goals_jonah') || '[]');
+      const todayISO = new Date().toISOString().slice(0,10);
+      goals.forEach(g=>{ if(g.date === todayISO){ items.push(`${EMOJI[g.pillar]||''} ${g.title}`); }});
+      scheduleUl.innerHTML = items.length ? items.map(t=>`<li>${escapeHtml(t)}</li>`).join('') : '<li>No scheduled activities.</li>';
+    }
+
     function escapeHtml(s){ return (s||'').replace(/[&<>"']/g, m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;', "'":'&#39;' }[m])); }
 
     renderList();
+    renderSchedule();
   </script>
   <link rel="stylesheet" href="./css/settings.css">
   <script type="module" src="./js/settings.js"></script>

--- a/jonah-swirl/index.html
+++ b/jonah-swirl/index.html
@@ -17,8 +17,9 @@
       <button id="btnSwirl" class="pill active" aria-pressed="true">Swirlface</button>
       <button id="btnStructured" class="pill">Structured</button>
     </nav>
-    <button id="dropCrumb" class="pill">Drop Crumb</button>
+    <a id="enterDay" class="pill" href="./day.html">Enter Day</a>
     <a class="btn btn-ghost" href="./grandma-plan.html">🗒️ Plan (Upcoming)</a>
+    <a class="btn btn-ghost" href="./calendar.html">📅 Schedule</a>
   </header>
 
   <!-- POND + SWIRL CENTER -->
@@ -31,17 +32,14 @@
       <!-- minimalist spiral using SVG so we avoid images -->
       <svg viewBox="0 0 200 200" class="swirl-svg">
         <path d="M100,100
-                 m-5,0
-                 a5,5 0 1,0 10,0
-                 m-15,0
-                 a15,15 0 1,0 30,0
-                 m-30,0
-                 a30,30 0 1,0 60,0
-                 m-45,0
-                 a45,45 0 1,0 90,0
-                 m-60,0
-                 a60,60 0 1,0 120,0"
-              fill="none" stroke="currentColor" stroke-width="1.75" opacity="0.8"/>
+                 m0,-5
+                 a5,5   0 1,1 0,10
+                 a15,15 0 1,1 0,30
+                 a30,30 0 1,1 0,60
+                 a45,45 0 1,1 0,90
+                 a60,60 0 1,1 0,120"
+              fill="none" stroke="currentColor" stroke-width="1.75"
+              stroke-linecap="round" stroke-linejoin="round" opacity="0.8"/>
       </svg>
     </div>
 
@@ -50,7 +48,7 @@
     <button class="token" data-pillar="self" data-app="Self" style="--hue: 96; --sat: 62%; --lit: 68%;">Self</button>
     <button class="token" data-pillar="family" data-app="Family &amp; Home" style="--hue: 42; --sat: 72%; --lit: 66%;">Family</button>
     <button class="token" data-pillar="rrr" data-app="RRR" style="--hue: 210; --sat: 65%; --lit: 72%;">RRR</button>
-    <button class="token" data-pillar="secular" data-app="Secular Employment" style="--hue: 12; --sat: 70%; --lit: 68%;">Secular Employment</button>
+    <button class="token" data-pillar="work" data-app="Secular Employment" style="--hue: 12; --sat: 70%; --lit: 68%;">Secular Employment</button>
 
     <!-- Sparkles (very subtle) -->
     <div class="sparkles" aria-hidden="true"></div>

--- a/jonah-swirl/js/hub.js
+++ b/jonah-swirl/js/hub.js
@@ -5,11 +5,15 @@ const tokens = Array.from(document.querySelectorAll('.token'));
 
 function rand(min, max){ return Math.random() * (max - min) + min; }
 
+const isMobile = window.matchMedia('(max-width: 600px)').matches;
+const R_MIN = isMobile ? 90  : 150;
+const R_MAX = isMobile ? 160 : 260;
+
 tokens.forEach((t, i) => {
   // randomize orbits so each circle feels alive
   const startAngle = rand(0, 360);
-  const radius     = rand(150, 260);      // distance from center
-  const duration   = rand(26, 46);        // seconds per revolution
+  const radius     = rand(R_MIN, R_MAX);      // distance from center
+  const duration   = rand(26, 46);            // seconds per revolution
 
   t.style.setProperty('--angle', `${startAngle}deg`);
   t.style.setProperty('--radius', `${radius}px`);
@@ -29,7 +33,6 @@ tokens.forEach((t) => {
 // ~lines 80-150: mode toggles (Swirlface ↔ Structured) + crumb capture
 const btnSwirl      = document.getElementById('btnSwirl');
 const btnStructured = document.getElementById('btnStructured');
-const dropCrumb     = document.getElementById('dropCrumb');
 
 function setMode(mode){
   document.body.classList.toggle('mode-swirl',      mode === 'swirl');
@@ -41,20 +44,13 @@ function setMode(mode){
     tokens.forEach((t, i) => {
       const angle = (360 / tokens.length) * i;
       t.style.setProperty('--angle', `${angle}deg`);
-      t.style.setProperty('--radius', `210px`);
+      t.style.setProperty('--radius', `${isMobile ? 140 : 210}px`);
     });
   }
 }
 
 btnSwirl.addEventListener('click',      () => setMode('swirl'));
 btnStructured.addEventListener('click', () => setMode('structured'));
-
-dropCrumb.addEventListener('click', () => {
-  const text = prompt('Drop a crumb:');
-  if(text && text.trim()){
-    alert('Crumb saved and auto-sorted!');
-  }
-});
 
 // start in Swirlface mode
 setMode('swirl');


### PR DESCRIPTION
## Summary
- Add Enter Day button and Schedule link on Jonah's main page
- Show today's scheduled activities on the day entry page
- Introduce printable calendar view for Jonah's weekly schedule
- Smooth spiral graphic and mobile-friendly layout on home screen
- Resolve lingering HTML artifacts and align pillar tokens across pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c644933a8c832eaf343a023cd90d4b