### PR TITLE
Refine home, schedule, and terminology

### DIFF
--- a/jonah-swirl/css/hub.css
+++ b/jonah-swirl/css/hub.css
@@ -53,6 +53,7 @@ body{
 }
 .pill.active{ background:#fff; box-shadow: var(--glow-strong); }
 .modes{ display:flex; gap:8px; }
+#crumbBox{ flex:1; min-width:160px; }
 
 /* ~lines 80-144: pond + swirl + ripples */
 #pond{
@@ -103,6 +104,12 @@ body{
 }
 @keyframes breathe{ 0%,100%{ transform:scale(1)} 50%{ transform:scale(1.03)} }
 .swirl-svg{ width:82%; height:82%; }
+.enter-day{
+  position:absolute; left:50%; top:50%; transform:translate(-50%,-50%);
+  width:90px; height:130px; border-radius:60px 60px 8px 8px;
+  background:rgba(255,255,255,0.75); box-shadow: var(--glow-strong);
+  display:block;
+}
 
 /* ~lines 146-220: tokens (circles → doors) */
 .token{

--- a/jonah-swirl/day.html
+++ b/jonah-swirl/day.html
@@ -18,7 +18,7 @@
     </header>
 
     <section id="schedule" class="card">
-      <h2>Today's Plan</h2>
+      <h2>Today's Schedule</h2>
       <ul id="scheduleList"></ul>
     </section>
 
@@ -26,7 +26,7 @@
       <label class="row">
         <span class="lab">Pillar</span>
         <select id="pillar" name="pillar" required>
-          <option value="divine">👑 Divine</option>
+          <option value="divine">👑 Spiritual Routine</option>
           <option value="family">🏠 Home</option>
           <option value="self">🌱 Self</option>
           <option value="rrr">📚 Skills</option>
@@ -155,6 +155,13 @@
             li.textContent = `${PILL_EMOJI[pillar]||''} ${val}`;
             scheduleList.appendChild(li);
           }
+        });
+        const goals = JSON.parse(localStorage.getItem('swirl_goals_jonah') || '[]');
+        const todayISO = new Date().toISOString().slice(0,10);
+        goals.filter(g=>g.date===todayISO).forEach(g=>{
+          const li = document.createElement('li');
+          li.textContent = `${PILL_EMOJI[g.pillar]||''} ${g.title}`;
+          scheduleList.appendChild(li);
         });
       }catch{}
     }

--- a/jonah-swirl/grandma-plan.html
+++ b/jonah-swirl/grandma-plan.html
@@ -43,7 +43,7 @@
       <h2>Simple Goals & Appointments</h2>
       <form id="goalForm" class="row">
         <select id="gPillar" aria-label="Pillar">
-          <option value="divine">👑 Divine</option>
+          <option value="divine">👑 Spiritual Routine</option>
           <option value="family">🏠 Home</option>
           <option value="self">🌱 Self</option>
           <option value="rrr">📚 Skills</option>

--- a/jonah-swirl/index.html
+++ b/jonah-swirl/index.html
@@ -17,9 +17,8 @@
       <button id="btnSwirl" class="pill active" aria-pressed="true">Swirlface</button>
       <button id="btnStructured" class="pill">Structured</button>
     </nav>
-    <button id="dropCrumb" class="pill">Drop Crumb</button>
-    <a class="btn btn-ghost" href="./day.html">✍️ Enter Day</a>
-    <a class="btn btn-ghost" href="./grandma-plan.html">🗒️ Plan (Upcoming)</a>
+    <input id="crumbBox" class="pill" placeholder="Drop a crumb…" x-webkit-speech aria-label="Drop a crumb" />
+    <a class="btn btn-ghost" href="./weekly.html">🗓️ Schedule</a>
   </header>
 
   <!-- POND + SWIRL CENTER -->
@@ -29,30 +28,19 @@
       <p>Jonahs Swirl School</p>
     </div>
     <div class="swirl" aria-hidden="true">
-      <!-- minimalist spiral using SVG so we avoid images -->
       <svg viewBox="0 0 200 200" class="swirl-svg">
-        <path d="M100,100
-                 m-5,0
-                 a5,5 0 1,0 10,0
-                 m-15,0
-                 a15,15 0 1,0 30,0
-                 m-30,0
-                 a30,30 0 1,0 60,0
-                 m-45,0
-                 a45,45 0 1,0 90,0
-                 m-60,0
-                 a60,60 0 1,0 120,0"
-              fill="none" stroke="currentColor" stroke-width="1.75" opacity="0.8"
-              stroke-linecap="round" stroke-linejoin="round"/>
+        <path id="spiralPath" fill="none" stroke="currentColor" stroke-width="1.75" opacity="0.8"
+              stroke-linecap="round" stroke-linejoin="round"></path>
       </svg>
     </div>
+    <a id="enterDay" class="enter-day" href="./day.html" aria-label="Enter Day"></a>
 
     <!-- FLOATING PILLAR TOKENS -->
-    <button class="token" data-pillar="divine" data-app="Theocratic Education" style="--hue: 288; --sat: 58%; --lit: 70%;">Theocratic</button>
+    <button class="token" data-pillar="divine" data-app="Spiritual Routine" style="--hue: 288; --sat: 58%; --lit: 70%;">Spiritual Routine</button>
     <button class="token" data-pillar="self" data-app="Self" style="--hue: 96; --sat: 62%; --lit: 68%;">Self</button>
     <button class="token" data-pillar="family" data-app="Family &amp; Home" style="--hue: 42; --sat: 72%; --lit: 66%;">Family</button>
     <button class="token" data-pillar="rrr" data-app="RRR" style="--hue: 210; --sat: 65%; --lit: 72%;">RRR</button>
-    <button class="token" data-pillar="secular" data-app="Secular Employment" style="--hue: 12; --sat: 70%; --lit: 68%;">Secular Employment</button>
+    <button class="token" data-pillar="work" data-app="Work" style="--hue: 12; --sat: 70%; --lit: 68%;">Work</button>
 
     <!-- Sparkles (very subtle) -->
     <div class="sparkles" aria-hidden="true"></div>

--- a/jonah-swirl/js/blooms.js
+++ b/jonah-swirl/js/blooms.js
@@ -73,7 +73,7 @@ export function renderPillarBars(root, pillars){
   root.innerHTML = '';
   const total = Object.values(pillars).reduce((a,b)=>a+b,0) || 1;
   const labels = {
-    divine:'👑 Divine', family:'🏠 Home', self:'🌱 Self', rrr:'📚 Skills', work:'💵 Work'
+    divine:'👑 Spiritual Routine', family:'🏠 Home', self:'🌱 Self', rrr:'📚 Skills', work:'💵 Work'
   };
   Object.keys(labels).forEach(key=>{
     const c = pillars[key]||0;

--- a/jonah-swirl/js/hub.js
+++ b/jonah-swirl/js/hub.js
@@ -29,7 +29,7 @@ tokens.forEach((t) => {
 // ~lines 80-150: mode toggles (Swirlface ↔ Structured) + crumb capture
 const btnSwirl      = document.getElementById('btnSwirl');
 const btnStructured = document.getElementById('btnStructured');
-const dropCrumb     = document.getElementById('dropCrumb');
+const crumbBox      = document.getElementById('crumbBox');
 
 function setMode(mode){
   document.body.classList.toggle('mode-swirl',      mode === 'swirl');
@@ -49,12 +49,27 @@ function setMode(mode){
 btnSwirl.addEventListener('click',      () => setMode('swirl'));
 btnStructured.addEventListener('click', () => setMode('structured'));
 
-dropCrumb.addEventListener('click', () => {
-  const text = prompt('Drop a crumb:');
-  if(text && text.trim()){
+crumbBox?.addEventListener('change', () => {
+  const text = crumbBox.value.trim();
+  if(text){
     alert('Crumb saved and auto-sorted!');
+    crumbBox.value = '';
   }
 });
 
 // start in Swirlface mode
 setMode('swirl');
+
+// draw smooth spiral
+function makeSpiralPath({cx=100, cy=100, startR=5, spacing=4, turns=4, steps=360}={}){
+  const TAU=Math.PI*2,total=turns*TAU,k=spacing/(2*Math.PI);
+  let d="";
+  for(let i=0;i<=steps;i++){
+    const t=i/steps,th=t*total+0.0001,r=startR+k*th;
+    const x=cx+r*Math.cos(th),y=cy+r*Math.sin(th);
+    d+= (i?` L ${x.toFixed(2)} ${y.toFixed(2)}`:`M ${x.toFixed(2)} ${y.toFixed(2)}`);
+  }
+  return d;
+}
+const spiralPath=document.getElementById('spiralPath');
+if(spiralPath){ spiralPath.setAttribute('d', makeSpiralPath()); }

--- a/jonah-swirl/js/planner.js
+++ b/jonah-swirl/js/planner.js
@@ -227,7 +227,7 @@ function readPlan(){ return readJSON(KEYS.plan, '{"weekStartISO":"","monthISO":"
 function readJSON(key, fallback){ try{ return JSON.parse(localStorage.getItem(key)||fallback); }catch{ return JSON.parse(fallback); } }
 function writeJSON(key, val){ localStorage.setItem(key, JSON.stringify(val)); }
 
-function nameOf(p){ return ({divine:'Divine',family:'Home',self:'Self',rrr:'Skills',work:'Work'})[p] || p; }
+function nameOf(p){ return ({divine:'Spiritual Routine',family:'Home',self:'Self',rrr:'Skills',work:'Work'})[p] || p; }
 function cellKey(cell){ return `${cell.dataset.pillar}_${cell.dataset.day}`; }
 function cellFromKey(key){ const [pillar, day] = key.split('_'); return {pillar, day}; }
 function nextMondayISO(){

--- a/jonah-swirl/js/swirlfeed.js
+++ b/jonah-swirl/js/swirlfeed.js
@@ -12,7 +12,7 @@ let currentPill = 'all';
 let q = '';
 
 const PILL_LABEL = {
-  divine: '👑 Divine',
+  divine: '👑 Spiritual Routine',
   family: '🏠 Home',
   self:   '🌱 Self',
   rrr:    '📚 Skills',

--- a/jonah-swirl/swirlfeed.html
+++ b/jonah-swirl/swirlfeed.html
@@ -18,7 +18,7 @@
     <section class="filters" aria-label="Filter crumbs">
       <div class="chips" role="tablist">
         <button class="chip is-active" data-pill="all" role="tab" aria-selected="true">All</button>
-        <button class="chip" data-pill="divine" role="tab" aria-selected="false">👑 Divine</button>
+        <button class="chip" data-pill="divine" role="tab" aria-selected="false">👑 Spiritual Routine</button>
         <button class="chip" data-pill="family" role="tab" aria-selected="false">🏠 Home</button>
         <button class="chip" data-pill="self"   role="tab" aria-selected="false">🌱 Self</button>
         <button class="chip" data-pill="rrr"    role="tab" aria-selected="false">📚 Skills</button>

--- a/jonah-swirl/weekly.html
+++ b/jonah-swirl/weekly.html
@@ -19,6 +19,7 @@
         <button id="nextWeek" class="btn btn-ghost" type="button">Next ▶︎</button>
         <button id="openSettings" class="btn btn-ghost" type="button">⚙︎ Settings</button>
         <button id="openEvidence" class="btn" type="button">📄 Evidence Pack</button>
+        <button id="printWeek" class="btn" type="button">🖨 Print</button>
       </div>
     </header>
 
@@ -71,6 +72,7 @@
     const thisBtn = document.getElementById('thisWeek');
     const btnJson = document.getElementById('btnJson');
     const btnCsv  = document.getElementById('btnCsv');
+    const printBtn = document.getElementById('printWeek');
     document.getElementById('openSettings')?.addEventListener('click', ()=> window.openSettings && window.openSettings());
 
     function render(){
@@ -94,6 +96,8 @@
       url.searchParams.set('w', weekOffset);
       location.href = url.toString();
     };
+
+    printBtn.onclick = ()=> window.print();
 
     // initial
     render();


### PR DESCRIPTION
## Summary
- Add inline crumb box and central door link on home screen with smooth SVG spiral and schedule shortcut.
- Rename the Divine pillar to Spiritual Routine across pages and scripts.
- Show "Today's Schedule" on day view by combining plan and goal entries; add weekly print option.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c64b269e08832e9793e361fca17f79