### PR TITLE
Add SwirlFeed and Day Journal features

### DIFF
--- a/swirl-system/css/base.css
+++ b/swirl-system/css/base.css
@@ -42,3 +42,12 @@ textarea {
   display: block;
   margin-bottom: 5px;
 }
+
+:root { --bg:#0d0f12; --fg:#f6f7fb; --accent:#8ae; }
+body { margin:0; background:var(--bg); color:var(--fg); font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+label { display:grid; gap:6px; margin:10px 0; }
+input, select, textarea, button { font: inherit; }
+.thumb { width:100%; max-height: 260px; object-fit: cover; border-radius: 10px; border:1px solid #22283a; }
+.crumb { background:#111520; border:1px solid #22283a; border-radius:12px; padding:10px; margin:10px 0; }
+.crumb .head { display:flex; justify-content:space-between; color:#9fb0c6; margin-bottom:8px; }
+.hidden { display:none !important; }

--- a/swirl-system/css/dayview.css
+++ b/swirl-system/css/dayview.css
@@ -1,0 +1,18 @@
+.day-body { background:#0d0f12; color:#f6f7fb; }
+.topbar { display:flex; align-items:center; justify-content:space-between; padding:12px 16px; position:sticky; top:0; background:#11131a; border-bottom:1px solid #212634; }
+.topbar .brand { color:#8ae; text-decoration:none; }
+
+.day-wrap { max-width:820px; margin:16px auto; padding:0 12px; display:grid; gap:24px; }
+.entries { display:grid; gap:16px; }
+.day-card { background:#111520; border:1px solid #21283a; border-radius:14px; padding:12px; }
+.day-card header { display:flex; justify-content:space-between; color:#9fb0c6; margin-bottom:8px; }
+.day-card .pic img { width:100%; display:block; border-radius:10px; }
+.day-card .txt { margin:10px 0; line-height:1.5; }
+.day-card .parts { color:#aab9ce; font-size:14px; }
+
+.comments h2 { margin:0; }
+.comments form { display:grid; gap:8px; background:#101522; border:1px solid #1e2535; border-radius:12px; padding:12px; }
+.comments button { background:#8ae; color:#0c1020; border:none; padding:8px 12px; border-radius:10px; cursor:pointer; }
+.comment-list { list-style:none; padding:0; margin:0; display:grid; gap:8px; }
+.comment-list li { background:#0f1320; border:1px solid #1d2434; border-radius:10px; padding:8px 10px; }
+.comment-list .when { color:#8aa0ba; margin-right:6px; }

--- a/swirl-system/css/swirlfeed.css
+++ b/swirl-system/css/swirlfeed.css
@@ -1,0 +1,12 @@
+.feed-body { background: var(--bg, #0d0f12); color: var(--fg,#f6f7fb); }
+.topbar { display:flex; align-items:center; justify-content:space-between; padding:12px 16px; position:sticky; top:0; background:#11131a; border-bottom:1px solid #212634; }
+.topbar .brand { color:#8ae; text-decoration:none; }
+.feed { max-width:720px; margin:16px auto; padding: 0 12px; display:grid; gap:16px; }
+.post { background:#141823; border:1px solid #22283a; border-radius:16px; overflow:hidden; box-shadow: 0 8px 24px rgba(0,0,0,0.25); }
+.post-head { display:flex; gap:8px; justify-content:space-between; padding:10px 12px; font-size:14px; color:#9fb0c6; }
+.media img { display:block; width:100%; height:auto; }
+.text { padding:12px; font-size:16px; line-height:1.5; }
+.meta { display:flex; gap:12px; align-items:center; padding:10px 12px 14px; border-top:1px solid #212634; }
+.meta .open-day { background:#8ae; color:#0c1020; border:none; padding:6px 10px; border-radius:10px; cursor:pointer; }
+.meta .fav { background:transparent; color:#9fb0c6; border:1px solid #2a2f40; padding:6px 10px; border-radius:10px; cursor:pointer; }
+.meta .fav.faved { color:#ff8ac5; border-color:#ff8ac5; }

--- a/swirl-system/data/honeycomb.json
+++ b/swirl-system/data/honeycomb.json
@@ -1,0 +1,10 @@
+[
+  { "pillar": "📚 RRR", "idea": "Draw Nebuchadnezzar’s statue with labeled sections." },
+  { "pillar": "📚 RRR", "idea": "Place the 7 world powers on a simple timeline." },
+  { "pillar": "👑 Divine", "idea": "Find 1 verse from Daniel that mentions a world power and copy it neatly." },
+  { "pillar": "📚 RRR", "idea": "Match each world power to its symbol (lion, bear, leopard…)." },
+  { "pillar": "👑 Divine", "idea": "Write a one-sentence prayer about staying faithful under pressure like Daniel." },
+  { "pillar": "📚 RRR", "idea": "Color a world map and mark Babylon, Medo-Persia, Greece, Rome." },
+  { "pillar": "📚 RRR", "idea": "Explain the 'Politically Divided Toes' in your own words (1-2 sentences)." },
+  { "pillar": "👑 Divine", "idea": "Pick one modern news story and ask: how do we stay neutral and faithful today?" }
+]

--- a/swirl-system/day.html
+++ b/swirl-system/day.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Day Journal · Jonah</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <link rel="stylesheet" href="./css/base.css"/>
+  <link rel="stylesheet" href="./css/dayview.css"/>
+</head>
+<body class="day-body">
+  <header class="topbar">
+    <a class="brand" href="./feed.html">← SwirlFeed</a>
+    <h1 id="dayTitle">Day Journal</h1>
+    <nav class="nav">
+      <a href="./index.html">＋ Drop Crumb</a>
+    </nav>
+  </header>
+
+  <main class="day-wrap">
+    <section id="entries" class="entries"></section>
+
+    <section class="comments">
+      <h2>Add a Thought</h2>
+      <form id="commentForm">
+        <label>Comment
+          <textarea id="commentText" rows="3" placeholder="A sentence is enough…"></textarea>
+        </label>
+        <label>Part (optional)
+          <select id="commentPart">
+            <option value="">—</option>
+            <option>Otter</option>
+            <option>Ron</option>
+            <option>Lucy</option>
+            <option>Glimmer</option>
+          </select>
+        </label>
+        <button type="submit">Add Comment</button>
+      </form>
+      <ul id="commentList" class="comment-list"></ul>
+    </section>
+  </main>
+
+  <script type="module" src="./js/dayview.js"></script>
+</body>
+</html>

--- a/swirl-system/feed.html
+++ b/swirl-system/feed.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>SwirlFeed · Jonah</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <link rel="stylesheet" href="./css/base.css"/>
+  <link rel="stylesheet" href="./css/swirlfeed.css"/>
+</head>
+<body class="feed-body">
+  <header class="topbar">
+    <a class="brand" href="./index.html">＋ Drop a Crumb</a>
+    <h1>SwirlFeed</h1>
+    <nav class="nav">
+      <a href="./day.html">Day Journal</a>
+    </nav>
+  </header>
+
+  <main id="feed" class="feed"></main>
+
+  <template id="postTpl">
+    <article class="post">
+      <div class="post-head">
+        <span class="pillar"></span>
+        <span class="date"></span>
+      </div>
+      <div class="media"></div>
+      <p class="text"></p>
+      <div class="meta">
+        <span class="parts"></span>
+        <button class="open-day">Open Day</button>
+        <button class="fav">♡</button>
+      </div>
+    </article>
+  </template>
+
+  <script type="module" src="./js/swirlfeed.js"></script>
+</body>
+</html>

--- a/swirl-system/index.html
+++ b/swirl-system/index.html
@@ -1,36 +1,46 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="utf-8"/>
   <title>SwirlSystem</title>
-  <link rel="stylesheet" href="css/base.css">
+  <link rel="stylesheet" href="./css/base.css"/>
 </head>
 <body>
-  <h1>SwirlSystem</h1>
-  <form id="crumb-form">
-    <label for="photo">Photo</label>
-    <input type="file" id="photo" accept="image/*">
+  <!-- DROP A CRUMB (PHASE 1+) -->
+  <main style="max-width:720px;margin:2rem auto;padding:1rem;">
+    <header style="display:flex;justify-content:space-between;align-items:center;gap:12px;">
+      <h1>Drop a Crumb</h1>
+      <nav><a href="./feed.html" style="color:#8ae;text-decoration:none;">Open SwirlFeed →</a></nav>
+    </header>
 
-    <label for="caption">Caption</label>
-    <textarea id="caption"></textarea>
+    <form id="crumbForm">
+      <label>Pillar
+        <select id="pillar">
+          <option>👑 Divine</option>
+          <option>🏡 Family</option>
+          <option>🌱 Self+Parts</option>
+          <option>📚 RRR</option>
+          <option>💵 Earning</option>
+        </select>
+      </label>
 
-    <label for="pillar">Pillar</label>
-    <select id="pillar">
-      <option value="divine">👑 Divine Education</option>
-      <option value="family">🏡 Family &amp; Home</option>
-      <option value="self">🌱 Self + Parts</option>
-      <option value="rrr">📚 RRR</option>
-      <option value="work">💵 Employment &amp; Future</option>
-    </select>
+      <label>What happened?
+        <input id="text" placeholder="Short sentence…" />
+      </label>
 
-    <label for="part">Part (optional)</label>
-    <input type="text" id="part">
+      <label>Photo (optional)
+        <input id="photo" type="file" accept="image/*" />
+      </label>
 
-    <button type="submit">Drop Crumb</button>
-  </form>
+      <!-- Starter Parts/Feelings/Needs + Real-life tag + Micro-goal -->
+      <div id="extras"></div>
 
-  <ul id="crumb-list"></ul>
+      <button type="submit">Save</button>
+    </form>
 
-  <script type="module" src="js/crumb-entry.js"></script>
+    <h2>Recent Crumbs</h2>
+    <ul id="crumbList"></ul>
+  </main>
+  <script type="module" src="./js/crumb-entry.js"></script>
 </body>
 </html>

--- a/swirl-system/js/crumb-entry.js
+++ b/swirl-system/js/crumb-entry.js
@@ -1,59 +1,123 @@
-import { loadCrumbs, saveCrumbs } from './storage.js';
+// Phase 1+ : Drop-a-crumb (photo, text, pillar) + starter Parts/Feelings/Needs + optional micro-goal prompt
+import { load, save } from './storage.js';
+
+const KEY = 'crumbs';
 
 const PILLAR_LABELS = {
-  divine: '👑 Divine Education',
-  family: '🏡 Family & Home',
-  self: '🌱 Self + Parts',
-  rrr: '📚 RRR',
-  work: '💵 Employment & Future',
+  'divine':'👑 Divine', 'family':'🏡 Family', 'self':'🌱 Self+Parts', 'rrr':'📚 RRR', 'work':'💵 Earning',
+  '👑 Divine':'👑 Divine','🏡 Family':'🏡 Family','🌱 Self+Parts':'🌱 Self+Parts','📚 RRR':'📚 RRR','💵 Earning':'💵 Earning'
 };
 
-document.addEventListener('DOMContentLoaded', () => {
-  const form = document.getElementById('crumb-form');
-  const list = document.getElementById('crumb-list');
-  let crumbs = loadCrumbs();
-  crumbs.forEach(renderCrumb);
+const feelings = ['Happy','Sad','Tired','Calm','Excited'];
+const needs    = ['Rest','Play','Help','Comfort','Space'];
+const parts    = ['Otter','Ron','Lucy','Glimmer'];
 
-  form.addEventListener('submit', (e) => {
-    e.preventDefault();
-    const fileInput = document.getElementById('photo');
-    const caption = document.getElementById('caption').value.trim();
-    const pillarSelect = document.getElementById('pillar');
-    const pillar = pillarSelect.value;
-    const part = document.getElementById('part').value.trim();
-    const newCrumb = { id: Date.now(), caption, pillar, part };
-    const file = fileInput.files[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = () => {
-        newCrumb.image = reader.result;
-        crumbs.push(newCrumb);
-        saveCrumbs(crumbs);
-        renderCrumb(newCrumb);
-        form.reset();
-      };
-      reader.readAsDataURL(file);
-    } else {
-      crumbs.push(newCrumb);
-      saveCrumbs(crumbs);
-      renderCrumb(newCrumb);
-      form.reset();
-    }
+function qs(id){ return document.getElementById(id); }
+function renderList(){
+  const list = qs('crumbList');
+  const data = load(KEY, []);
+  list.innerHTML = data.slice().reverse().map(c => {
+    const when = new Date(c.date).toLocaleString();
+    const pill = PILLAR_LABELS[c.pillar] || c.pillar || '🌀';
+    const img  = c.photo ? `<img class="thumb" src="${c.photo}" alt="">` : '';
+    const meta = [
+      c.part ? `Part: ${c.part}` : '',
+      c.feeling ? `Feeling: ${c.feeling}` : '',
+      c.need ? `Need: ${c.need}` : '',
+      c.goal?.skill ? `Goal: ${c.goal.skill} → ${c.goal.nextStep}` : ''
+    ].filter(Boolean).join(' · ');
+    return `<li class="crumb">
+      <div class="head"><span class="pill">${pill}</span><span class="when">${when}</span></div>
+      ${img}
+      <p>${c.text||''}</p>
+      ${meta ? `<p class="meta">${meta}</p>` : ''}
+    </li>`;
+  }).join('');
+}
+
+function readFileAsDataURL(file){
+  return new Promise(res=>{
+    if(!file) return res(null);
+    const fr = new FileReader();
+    fr.onload = () => res(fr.result);
+    fr.readAsDataURL(file);
+  });
+}
+
+window.addEventListener('DOMContentLoaded', ()=>{
+  const form = qs('crumbForm');
+  const pillarEl = qs('pillar');
+  const textEl = qs('text');
+  const photoEl = qs('photo');
+
+  // Inject starter selects if not present
+  const extras = qs('extras');
+  if (extras && !qs('feeling')){
+    extras.innerHTML = `
+      <label>Feeling (optional)
+        <select id="feeling"><option value="">—</option>${feelings.map(x=>`<option>${x}</option>`).join('')}</select>
+      </label>
+      <label>Need (optional)
+        <select id="need"><option value="">—</option>${needs.map(x=>`<option>${x}</option>`).join('')}</select>
+      </label>
+      <label>Part (optional)
+        <select id="part"><option value="">—</option>${parts.map(x=>`<option>${x}</option>`).join('')}</select>
+      </label>
+      <label>Real-life tag (optional)
+        <select id="reallife"><option value="">—</option><option>🐾 Pet Call</option><option>🧻 Toilet Time</option></select>
+      </label>
+      <div id="goalWrap" class="goal hidden">
+        <h3>Micro Goal</h3>
+        <label>Skill <input id="goalSkill" placeholder="e.g., Responsibility"/></label>
+        <label>Next step <input id="goalNext" placeholder="e.g., Carry wipes & count pets"/></label>
+        <label>Helper part
+          <select id="goalPart"><option value="">—</option>${parts.map(x=>`<option>${x}</option>`).join('')}</select>
+        </label>
+      </div>
+    `;
+  }
+
+  // Show/hide micro-goal when a real-life tag is chosen
+  qs('reallife')?.addEventListener('change', e=>{
+    qs('goalWrap')?.classList.toggle('hidden', !e.target.value);
   });
 
-  function renderCrumb(crumb) {
-    const li = document.createElement('li');
-    if (crumb.image) {
-      const img = document.createElement('img');
-      img.src = crumb.image;
-      img.alt = crumb.caption || '';
-      li.appendChild(img);
+  form?.addEventListener('submit', async (e)=>{
+    e.preventDefault();
+    const text   = textEl.value.trim();
+    const pillar = PILLAR_LABELS[pillarEl.value] || pillarEl.value;
+    if(!text) return;
+
+    const photo = await readFileAsDataURL(photoEl.files?.[0]);
+    const data  = load(KEY, []);
+    const crumb = {
+      id: crypto.randomUUID(),
+      date: new Date().toISOString(),
+      pillar,
+      text,
+      photo: photo || null,
+      feeling: qs('feeling')?.value || '',
+      need: qs('need')?.value || '',
+      part: qs('part')?.value || '',
+    };
+
+    // attach micro-goal if visible
+    if (!qs('goalWrap')?.classList.contains('hidden')){
+      const skill = qs('goalSkill').value.trim();
+      const next  = qs('goalNext').value.trim();
+      const gpart = qs('goalPart').value.trim();
+      if (skill || next || gpart){
+        crumb.goal = { skill, nextStep: next, part: gpart };
+      }
     }
-    const text = document.createElement('p');
-    const partText = crumb.part ? ` (${crumb.part})` : '';
-    const pillarLabel = PILLAR_LABELS[crumb.pillar] || crumb.pillar;
-    text.textContent = `${pillarLabel}: ${crumb.caption}${partText}`;
-    li.appendChild(text);
-    list.appendChild(li);
-  }
+
+    data.push(crumb);
+    save(KEY, data);
+    form.reset();
+    // hide goal wrap again
+    qs('goalWrap')?.classList.add('hidden');
+    renderList();
+  });
+
+  renderList();
 });

--- a/swirl-system/js/dayview.js
+++ b/swirl-system/js/dayview.js
@@ -1,0 +1,73 @@
+import { load, save } from './storage.js';
+
+const CRUMBS = 'crumbs';
+const COMMENTS = 'comments'; // keyed by YYYY-MM-DD
+
+function q(k){ return document.querySelector(k); }
+function ymdFromQuery(){
+  const p = new URLSearchParams(location.search);
+  return p.get('d') || (new Date().toISOString().slice(0,10));
+}
+
+function sameDay(a,b){
+  const A = new Date(a), B = new Date(b);
+  return A.getFullYear()===B.getFullYear() && A.getMonth()===B.getMonth() && A.getDate()===B.getDate();
+}
+
+function groupForDay(day){
+  const data = load(CRUMBS, []);
+  return data.filter(c=>sameDay(c.date, day)).sort((a,b)=>new Date(a.date)-new Date(b.date));
+}
+
+function renderEntries(day){
+  const entries = q('#entries');
+  entries.innerHTML = '';
+  const items = groupForDay(day);
+  if (!items.length){
+    entries.innerHTML = `<p class="empty">No crumbs yet today. Add one from the entry page or drop a thought below.</p>`;
+    return;
+  }
+  items.forEach(c=>{
+    const card = document.createElement('article');
+    card.className = 'day-card';
+    card.innerHTML = `
+      <header>
+        <span class="pill">${c.pillar || '🌀'}</span>
+        <time>${new Date(c.date).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'})}</time>
+      </header>
+      ${c.photo ? `<div class="pic"><img src="${c.photo}" alt="crumb photo"></div>` : ''}
+      <p class="txt">${c.text || ''}</p>
+      ${c.parts?.length ? `<p class="parts">Parts: ${c.parts.join(', ')}</p>` : ''}
+    `;
+    entries.appendChild(card);
+  });
+}
+
+function renderComments(day){
+  const list = q('#commentList');
+  const map  = load(COMMENTS, {});
+  const arr  = map[day] || [];
+  list.innerHTML = arr.map(c=>`<li><span class="when">${new Date(c.at).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'})}</span> ${c.part?`<b>${c.part}</b>: `:''}${c.text}</li>`).join('');
+}
+
+function setupCommentForm(day){
+  const form = q('#commentForm');
+  form.addEventListener('submit', e=>{
+    e.preventDefault();
+    const text = q('#commentText').value.trim();
+    const part = q('#commentPart').value.trim();
+    if(!text) return;
+    const map = load(COMMENTS, {});
+    map[day] ??= [];
+    map[day].push({ id: crypto.randomUUID(), at: new Date().toISOString(), text, part });
+    save(COMMENTS, map);
+    form.reset();
+    renderComments(day);
+  });
+}
+
+const day = ymdFromQuery();
+q('#dayTitle').textContent = `Day Journal — ${day}`;
+renderEntries(day);
+renderComments(day);
+setupCommentForm(day);

--- a/swirl-system/js/swirlfeed.js
+++ b/swirl-system/js/swirlfeed.js
@@ -1,0 +1,58 @@
+import { load } from './storage.js';
+
+const KEY = 'crumbs';
+
+const PILLAR_ICON = {
+  '👑 Divine':'👑 Divine',
+  '🏡 Family':'🏡 Family',
+  '🌱 Self+Parts':'🌱 Self+Parts',
+  '📚 RRR':'📚 RRR',
+  '💵 Earning':'💵 Earning',
+  // also support old internal codes if any
+  'divine':'👑 Divine','family':'🏡 Family','self':'🌱 Self+Parts','rrr':'📚 RRR','work':'💵 Earning'
+};
+
+const feed = document.getElementById('feed');
+const tpl  = document.getElementById('postTpl');
+
+function byNewest(a,b){ return new Date(b.date) - new Date(a.date); }
+
+function ymd(dateStr){
+  const d = new Date(dateStr);
+  const y = d.getFullYear(), m = String(d.getMonth()+1).padStart(2,'0'), da = String(d.getDate()).padStart(2,'0');
+  return `${y}-${m}-${da}`;
+}
+
+function render(){
+  const data = load(KEY, []);
+  const posts = [...data].sort(byNewest);
+  feed.innerHTML = '';
+  posts.forEach(c=>{
+    const node = tpl.content.cloneNode(true);
+    node.querySelector('.pillar').textContent = PILLAR_ICON[c.pillar] || c.pillar || '🌀';
+    node.querySelector('.date').textContent   = new Date(c.date).toLocaleString();
+    node.querySelector('.text').textContent   = c.text || '';
+    node.querySelector('.parts').textContent  = (c.parts?.length ? `Parts: ${c.parts.join(', ')}` : '');
+
+    const media = node.querySelector('.media');
+    if (c.photo){
+      const img = document.createElement('img');
+      img.src = c.photo;
+      img.alt = 'crumb photo';
+      media.appendChild(img);
+    }
+
+    node.querySelector('.open-day').addEventListener('click',()=>{
+      // pass date via query param so day view groups all crumbs from that day
+      location.href = `./day.html?d=${encodeURIComponent(ymd(c.date))}`;
+    });
+
+    node.querySelector('.fav').addEventListener('click', (e)=>{
+      e.currentTarget.classList.toggle('faved');
+    });
+
+    feed.appendChild(node);
+  });
+}
+
+render();


### PR DESCRIPTION
## Summary
- Add Instagram-style SwirlFeed page to browse crumbs with images, pillars, and favorites
- Introduce Day Journal view with per-day entries and comment support
- Expand crumb entry with parts/feelings/needs, micro-goal form, and updated styling

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6b81eaee4832eb1af40d7c3edeac9