### PR TITLE
Integrate SwirlFeed into main crumb page

### DIFF
--- a/swirl-system/index.html
+++ b/swirl-system/index.html
@@ -4,13 +4,13 @@
   <meta charset="utf-8"/>
   <title>SwirlSystem</title>
   <link rel="stylesheet" href="./css/base.css"/>
+  <link rel="stylesheet" href="./css/swirlfeed.css"/>
 </head>
 <body>
   <!-- DROP A CRUMB (PHASE 1+) -->
   <main style="max-width:720px;margin:2rem auto;padding:1rem;">
     <header style="display:flex;justify-content:space-between;align-items:center;gap:12px;">
       <h1>Drop a Crumb</h1>
-      <nav><a href="./feed.html" style="color:#8ae;text-decoration:none;">Open SwirlFeed →</a></nav>
     </header>
 
     <form id="crumbForm">
@@ -38,9 +38,24 @@
       <button type="submit">Save</button>
     </form>
 
-    <h2>Recent Crumbs</h2>
-    <ul id="crumbList"></ul>
+    <section id="swirl-feed" class="feed"></section>
+    <template id="postTpl">
+      <article class="post">
+        <div class="post-head">
+          <span class="pillar"></span>
+          <span class="date"></span>
+        </div>
+        <div class="media"></div>
+        <p class="text"></p>
+        <div class="meta">
+          <span class="parts"></span>
+          <button class="open-day">Open Day</button>
+          <button class="fav">♡</button>
+        </div>
+      </article>
+    </template>
   </main>
   <script type="module" src="./js/crumb-entry.js"></script>
+  <script type="module" src="./js/swirlfeed.js"></script>
 </body>
 </html>

--- a/swirl-system/js/crumb-entry.js
+++ b/swirl-system/js/crumb-entry.js
@@ -15,6 +15,7 @@ const parts    = ['Otter','Ron','Lucy','Glimmer'];
 function qs(id){ return document.getElementById(id); }
 function renderList(){
   const list = qs('crumbList');
+  if(!list) return;
   const data = load(KEY, []);
   list.innerHTML = data.slice().reverse().map(c => {
     const when = new Date(c.date).toLocaleString();
@@ -111,13 +112,14 @@ window.addEventListener('DOMContentLoaded', ()=>{
       }
     }
 
-    data.push(crumb);
-    save(KEY, data);
-    form.reset();
-    // hide goal wrap again
-    qs('goalWrap')?.classList.add('hidden');
-    renderList();
-  });
+      data.push(crumb);
+      save(KEY, data);
+      document.dispatchEvent(new Event('crumbsChanged'));
+      form.reset();
+      // hide goal wrap again
+      qs('goalWrap')?.classList.add('hidden');
+      renderList();
+    });
 
   renderList();
 });

--- a/swirl-system/js/swirlfeed.js
+++ b/swirl-system/js/swirlfeed.js
@@ -12,7 +12,7 @@ const PILLAR_ICON = {
   'divine':'👑 Divine','family':'🏡 Family','self':'🌱 Self+Parts','rrr':'📚 RRR','work':'💵 Earning'
 };
 
-const feed = document.getElementById('feed');
+const feed = document.getElementById('swirl-feed') || document.getElementById('feed');
 const tpl  = document.getElementById('postTpl');
 
 function byNewest(a,b){ return new Date(b.date) - new Date(a.date); }
@@ -24,6 +24,7 @@ function ymd(dateStr){
 }
 
 function render(){
+  if(!feed || !tpl) return;
   const data = load(KEY, []);
   const posts = [...data].sort(byNewest);
   feed.innerHTML = '';
@@ -55,4 +56,5 @@ function render(){
   });
 }
 
+document.addEventListener('crumbsChanged', render);
 render();


### PR DESCRIPTION
## Summary
- Embed SwirlFeed directly in the main SwirlSystem page so recent crumbs show as card posts.
- Dispatch a `crumbsChanged` event whenever a new crumb is saved so the feed updates automatically.
- Allow SwirlFeed script to render on pages using either `swirl-feed` or `feed` container IDs.

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ba668844832ea520e834ca675152