### PR TITLE
Refine Swirl School palette and entry flow

### DIFF
--- a/assets/swirl.svg
+++ b/assets/swirl.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" aria-label="Swirl">
+  <title>Met, Not Grabbed</title>
+  <path d="M454 274c0 115-93 208-208 208S38 389 38 274 131 66 246 66c82 0 149 67 149 149 0 58-47 105-105 105-46 0-83-37-83-83 0-35 28-63 63-63 27 0 49 22 49 49"
+        fill="none" stroke="#4F6F5F" stroke-width="18" stroke-linecap="round"/>
+</svg>

--- a/css/home.css
+++ b/css/home.css
@@ -1,0 +1,94 @@
+/* Swirlface Core Palette — Jonah v1 (photo-derived) */
+/* neutrals */
+:root{
+  --ink: #1B1F33;
+  --ink-soft: #3A3F57;
+  --paper: #FAF7F2;      /* warm off-white background */
+  --veil: rgba(255,255,255,0.7);
+
+  /* pillar anchors */
+  --pillar-spiritual: #CFA9F2;  /* soft lilac (Spiritual Routine) */
+  --pillar-family:    #F2C156;  /* warm honey gold */
+  --pillar-self:      #CFE8DF;  /* seafoam/minty */
+  --pillar-rrr:       #BFD7F6;  /* sky blue */
+  --pillar-work:      #FFB38A;  /* peach/apricot */
+
+  /* supportive pastels from the photo */
+  --pastel-pink:   #F7B3C8;
+  --pastel-lilac:  #D9A7E1;
+  --pastel-peach:  #FFC29B;
+  --pastel-butter: #F7E5A3;
+  --pastel-sky:    #A7C7E7;
+
+  /* UI accents (IG-ish) */
+  --chip-fill: #FFFFFF;
+  --chip-border: #DFE3F3;
+  --chip-active: #F4F7FF;
+  --chip-accent: #EAF0FF;
+
+  /* gradients used for hero text / buttons */
+  --grad-hero: linear-gradient(180deg, #AFC8FF 0%, #D9A7E1 100%);
+  --grad-like: linear-gradient(135deg, #FF8FB2 0%, #FFB38A 100%);
+  --grad-save: linear-gradient(135deg, #B2F0E6 0%, #BFD7F6 100%);
+}
+
+/* Pillar utility classes */
+.pillar--spiritual { --pillar: var(--pillar-spiritual); }
+.pillar--family    { --pillar: var(--pillar-family); }
+.pillar--self      { --pillar: var(--pillar-self); }
+.pillar--rrr       { --pillar: var(--pillar-rrr); }
+.pillar--work      { --pillar: var(--pillar-work); }
+
+/* --- Swirlface landing mobile layout tweaks --- */
+body { background: var(--paper); color: var(--ink); }
+
+.swirl-tabs{
+  position: sticky; top: 0; z-index: 20;
+  display: flex; gap: 8px; padding: 10px 12px;
+  background: var(--veil); backdrop-filter: blur(10px);
+  border-radius: 14px; margin: 12px auto; max-width: 680px;
+  border: 1px solid var(--chip-border);
+}
+.tab{
+  appearance:none; border:1px solid var(--chip-border);
+  border-radius: 12px; padding:10px 14px; background: var(--chip-fill);
+  font: inherit; cursor:pointer; box-shadow:0 2px 8px rgba(0,0,0,.06);
+}
+.tab.is-active{ background: var(--chip-active); }
+.tab.accent{ background: var(--chip-accent); border-color:#BACEFF; }
+
+.hero{
+  position: relative; z-index: 10; padding: clamp(12px,4vw,24px) 16px 8px; text-align:center;
+}
+.hero-title{ margin:0 auto; max-width:22ch; line-height:1.1; display:grid; gap:6px; }
+.hero-kicker{
+  font-weight:700; font-size:clamp(18px,5vw,28px);
+  background: var(--grad-hero); -webkit-background-clip:text; background-clip:text; color:transparent;
+}
+.hero-main{ font-weight:800; font-size:clamp(22px,7vw,40px); color:var(--ink);
+  text-shadow: 0 1px 0 #fff, 0 14px 30px rgba(93,109,161,.22);
+}
+
+/* Decorative layers must sit under text */
+.bubbles-layer{ position:relative; z-index:1; pointer-events:none; }
+
+/* Orb labels */
+.orb-label{ font-weight:700; letter-spacing:.1px; text-shadow:0 1px 2px rgba(0,0,0,.25); }
+
+@media (max-width:420px){
+  .swirl-tabs{ gap:6px; padding:8px 8px; }
+  .tab{ padding:8px 10px; font-size:14px; }
+}
+
+/* Orb tinting */
+.orb{ width:140px; height:140px; border-radius:50%;
+      background: radial-gradient(120% 120% at 30% 20%, #fff 0%, var(--pillar) 70%);
+      box-shadow: 0 12px 30px rgba(0,0,0,.12); }
+
+/* Center swirl */
+.center-swirl{
+  position: relative; z-index: 5; display: grid; place-items:center;
+  margin: clamp(12px, 6vw, 40px) auto; width:min(240px, 60vw);
+  aspect-ratio:1/1; opacity:.9;
+}
+.center-swirl img{ width:100%; height:100%; }

--- a/index.html
+++ b/index.html
@@ -1,336 +1,41 @@
 <!doctype html>
-<html lang="en" class="ron">
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Ron — Modular Ledger (Ron • Lucy • Coffee)</title>
-
-  <!-- FONTS -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <!-- Inter (body), Cormorant (Lucy), Patrick Hand (Ron quote) -->
-  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600&family=Inter:wght@400;600&family=Patrick+Hand&display=swap" rel="stylesheet">
-
-  <!-- THEMES (versioned for cache-busting) -->
-  <link rel="stylesheet" href="theme/ron-style.css?v=8">
-  <link rel="stylesheet" href="theme/lucy-mode.css?v=8">
-  <link rel="stylesheet" href="theme/coffee-mode.css?v=8">
+  <title>Jonah’s Swirl School</title>
+  <link rel="stylesheet" href="css/home.css">
 </head>
 <body>
-  <div class="wrap">
-    <div class="panel" role="region" aria-label="Ron Ledger">
 
-      <!-- HEADER: title first, modes at right -->
-      <div class="header-line">
-        <h1 id="titleSwap">Money and Things</h1>
+<!-- TOP NAV TABS -->
+<nav class="swirl-tabs" aria-label="Modes">
+  <button class="tab is-active" onclick="location.href='/'" aria-current="page">Swirlface</button>
+  <button class="tab" onclick="location.href='/structured.html'">Structured</button>
+  <button class="tab accent" onclick="location.href='/swirl-system/index.html'">Drop a crumb</button>
+</nav>
 
-        <div class="modes" role="group" aria-label="Felt mode">
-          <label><input type="radio" name="felt" value="ron" checked> Ron</label>
-          <label><input type="radio" name="felt" value="lucy"> Lucy</label>
-          <label><input type="radio" name="felt" value="coffee"> Coffee</label>
-        </div>
-      </div>
+<!-- HERO TITLE (mobile-safe) -->
+<header class="hero">
+  <h1 class="hero-title">
+    <span class="hero-kicker">Learning</span>
+    <span class="hero-main">Jonah’s Swirl School</span>
+  </h1>
+</header>
 
-      <!-- Single quote line under title -->
-      <div id="quoteMain" class="muted quote-under-title"></div>
-      <div id="quoteSub" class="quote-sub muted" style="margin-top:2px;"></div>
+<!-- DECORATIVE BUBBLES -->
+<section class="bubbles-layer" aria-hidden="true">
+  <div class="orb pillar--rrr"><div class="orb-label">RRR</div></div>
+  <div class="orb pillar--self"><div class="orb-label">Self</div></div>
+  <div class="orb pillar--family"><div class="orb-label">Family</div></div>
+  <div class="orb pillar--spiritual"><div class="orb-label">Spiritual Routine</div></div>
+  <div class="orb pillar--work"><div class="orb-label">Employment</div></div>
+</section>
 
-      <!-- Character area (sprite + coffee mug) -->
-      <div class="header-right" aria-hidden="true" style="display:flex;gap:12px;align-items:flex-start;">
-        <!-- Ron face sprite (shown in Ron mode) -->
-        <div id="ronFace" class="ron-face pose-1" style="display:none"></div>
-        <!-- Coffee mug face (CSS controls visibility in Coffee mode) -->
-        <div class="coffee-face right-of-title expression-1"></div>
-      </div>
+<!-- CENTER SWIRL -->
+<div class="center-swirl">
+  <img src="/assets/swirl.svg" alt="Swirl — Met, Not Grabbed">
+</div>
 
-      <!-- TOP art (only Lucy uses an <img>) -->
-      <div class="top-art" aria-hidden="true">
-        <img id="lucyArt" class="art" alt="Lucy bubble art" style="display:none"
-             data-folder="assets" data-name="Lucy-bubble" data-ext="png,PNG,jpg,JPG,webp,WEBP">
-        <!-- legacy quote block kept for other modes; hidden in Ron via CSS -->
-        <div class="ron-quote-text"><div id="ronQuoteMain"></div><div id="ronQuoteSub"></div></div>
-      </div>
-
-      <hr class="quietline">
-
-      <!-- Settings -->
-      <details>
-        <summary><strong>Settings</strong> — Set-Aside % (Ron’s Jar)</summary>
-        <div class="row" style="margin-top:8px;">
-          <label>Set-Aside Percentage (% to reserve)
-            <input id="reservePct" type="number" step="0.1" min="0" max="100" placeholder="25">
-          </label>
-          <div class="inline" style="align-items:flex-end;">
-            <button id="saveSettings" type="button" class="secondary">Save</button>
-            <span class="muted">Used to compute “Set-Aside” and “Net”. Defaults to 25%.</span>
-          </div>
-        </div>
-      </details>
-
-      <hr class="quietline">
-
-      <!-- Form -->
-      <form id="entryForm" aria-describedby="savedMsg">
-        <div class="row">
-          <label>Date <input type="date" name="date" required></label>
-          <label>Client <input name="client" placeholder="Keely / Dexter / Witcher" required></label>
-        </div>
-
-        <div class="row-3">
-          <label>Service <input name="service" placeholder="Drop-in / Overnight / Litter clean" required></label>
-          <label>Amount (USD) <input type="number" step="0.01" name="amount" min="0" required placeholder="45.00"></label>
-          <label>Payment Method
-            <select name="method" required>
-              <option value="Cash">Cash</option><option value="Venmo">Venmo</option>
-              <option value="Zelle">Zelle</option><option value="Card">Card</option><option>Other</option>
-            </select>
-          </label>
-        </div>
-
-        <div class="row">
-          <label class="inline"><input type="checkbox" name="paid"> Mark as paid</label>
-          <label>Field Log <input name="notes" placeholder="Council remarks, special care, etc."></label>
-        </div>
-
-        <!-- Multi-day toggle -->
-        <div class="row" style="align-items:end;">
-          <label class="inline"><input id="multiToggle" type="checkbox" name="multiday"> Multi-day job?</label>
-          <div class="muted">For house sitting or multi-day care (Income only).</div>
-        </div>
-        <div id="multiFields" class="row-3" style="display:none;">
-          <label>Start Date <input type="date" name="startDate"></label>
-          <label>End Date   <input type="date" name="endDate"></label>
-          <label>Split evenly across days?
-            <select name="splitEvenly"><option value="yes">Yes — divide total amount</option><option value="no">No — keep on first day</option></select>
-          </label>
-        </div>
-        <div id="multiChoice" class="row" style="display:none;">
-          <label>Destination mode
-            <select name="expandMode"><option value="summary">One summary row</option><option value="expand">Auto-expand into daily rows</option></select>
-          </label>
-        </div>
-
-        <div class="inline" style="margin-top:10px;">
-          <div>
-            <button class="primary" type="submit" id="logBtn">Log to Ledger</button>
-            <button class="secondary" type="button" id="clearBtn">Wipe Slate</button>
-          </div>
-          <p id="savedMsg" class="success" role="status" aria-live="polite">Logged. Ron set it on the shelf. 🪵</p>
-        </div>
-      </form>
-
-      <div class="row" style="margin-top:14px;">
-        <div>
-          <h2>This Season’s Stack</h2>
-          <div class="inline" style="gap:8px; flex-wrap:wrap;">
-            <span class="pill" id="monthLabel">Month</span>
-            <span class="pill">Logs: <span id="countMonth">0</span></span>
-            <span class="pill">Gross Income: $<span id="grossMonth">0.00</span></span>
-            <span class="pill">Expenses: $<span id="expMonth">0.00</span></span>
-            <span class="pill">Net After Exp: $<span id="netMonth">0.00</span></span>
-            <span class="pill">Tax Set-Aside: $<span id="reserveMonth">0.00</span></span>
-          </div>
-          <button class="secondary" type="button" id="invoiceBtn" style="margin-top:10px;">Make Invoice</button>
-          <div class="card watermark" style="margin-top:10px;">
-            <div class="inline"><strong>Ledger</strong><small class="muted">The mountain remembers.</small></div>
-            <div class="table-wrap" style="margin-top:6px;">
-              <table aria-label="Logged entries">
-                <thead><tr>
-                  <th>Date / Range</th><th>Client</th><th>Category</th><th>Service</th><th>Platform</th><th>Method</th>
-                  <th class="right">Amount</th><th class="right">Set-Aside</th><th class="right">Net</th><th>Paid</th><th>Field Log</th>
-                </tr></thead>
-                <tbody id="rows"></tbody>
-                <tfoot><tr>
-                  <td colspan="6">Totals</td>
-                  <td class="right">$<span id="totalFoot">0.00</span></td>
-                  <td class="right">$<span id="totalReserveFoot">0.00</span></td>
-                  <td class="right">$<span id="totalNetFoot">0.00</span></td>
-                  <td colspan="2"></td>
-                </tr></tfoot>
-              </table>
-            </div>
-          </div>
-
-          <!-- BACKUPS -->
-          <div class="card" style="margin-top:12px; padding:12px;">
-            <div class="inline" style="justify-content:space-between; align-items:center;">
-              <strong>Backups</strong>
-              <small class="muted">Your data lives in this browser. Export often.</small>
-            </div>
-            <div class="actions" style="margin-top:8px; flex-wrap:wrap;">
-              <button type="button" class="primary" id="exportCsvBtn">Export CSV</button>
-              <button type="button" class="secondary" id="exportJsonBtn">Export JSON</button>
-              <label class="inline" style="gap:6px;">
-                <input type="file" id="importJsonInput" accept="application/json" style="display:none">
-                <button type="button" class="secondary" id="importJsonBtn">Import JSON</button>
-                <span class="muted">Restores entries from a JSON file</span>
-              </label>
-            </div>
-            <p class="footer">📦 Tip: Keep backups off-device (Drive, iCloud). Exports do not include your settings; that’s okay.</p>
-          </div>
-        </div>
-
-        <div class="right">
-          <h2 id="titleRight">The Mountain’s Record</h2>
-          <div>Logs: <strong id="countAll">0</strong></div>
-          <div>Gross Income: <strong>$<span id="totalAll">0.00</span></strong></div>
-          <div>Expenses: <strong>$<span id="expAll">0.00</span></strong></div>
-          <div>Net After Expenses: <strong>$<span id="netAll">0.00</span></strong></div>
-          <div>Tax Set-Aside: <strong>$<span id="reserveAll">0.00</span></strong></div>
-
-          <!-- Coffee mini (only in coffee mode) -->
-          <div id="coffeeMini" class="card" style="display:none; margin-top:12px;">
-            <div class="inline"><strong>Reading Timer</strong><button id="start10" class="secondary">10 min</button></div>
-            <div class="row" style="margin-top:8px;">
-              <label>DNF / Juice Box
-                <input id="coffeeNote" placeholder="Too many italics. Emotionally allergic.">
-              </label>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <p class="muted" style="margin-top:10px;">🦦 Nudge: Tides come four times a year — <strong>Apr 15 • Jun 15 • Sep 15 • Jan 15</strong></p>
-    </div>
-  </div>
-
-  <!-- Sparkle layer -->
-  <div class="sparkles" id="sparkles"></div>
-
-  <!-- Invoice helper -->
-  <script src="ui/invoice.js"></script>
-
-  <!-- MODULES -->
-  <script type="module">
-    import {resolveImage, resolveBgVar} from './ui/image-resolver.js';
-    import {current, initModeRadio} from './ui/modes.js';
-    import {showOnce} from './ui/quotes.js';
-    import * as store from './ui/storage.js';
-    import {wireForm} from './ui/ledger-form.js';
-    import {renderTable} from './ui/ledger-table.js';
-    import {renderSummaries} from './ui/summaries.js';
-    import {burst as sparklesBurst} from './ui/sparkles.js';
-    import {wireCoffeeMini} from './ui/coffee-mini.js';
-    import {applyCoffeeOnMode} from './ui/coffee-faces.js';
-    import {setRonPose, randomPose} from './ui/Ron-face.js';  // capital R
-
-    // Only Lucy has an <img> art now (Ron uses sprite)
-    resolveImage(document.getElementById('lucyArt'));
-
-    // CSS var backgrounds (case exact)
-    resolveBgVar('--bg-lucy',   'assets/Lucy-bokeh.png');
-    resolveBgVar('--bg-coffee','assets/coffee/coffee-paper.PNG');
-
-    // Mode init
-    initModeRadio(document.querySelectorAll('input[name="felt"]'), (m)=>{
-      titleUpdate(m);
-      artSwap(m);
-      showOnce(m);
-      applyCoffeeOnMode(m);
-      document.getElementById('coffeeMini').style.display = (m==='coffee') ? '' : 'none';
-
-      // Keep <html> mode classes in sync for CSS themes
-      document.documentElement.classList.toggle('ron',    m === 'ron');
-      document.documentElement.classList.toggle('lucy',   m === 'lucy');
-      document.documentElement.classList.toggle('coffee', m === 'coffee');
-
-      // Sprite visibility + default/random pose
-      const ronFace = document.getElementById('ronFace');
-      if (ronFace) {
-        ronFace.style.display = (m === 'ron') ? '' : 'none';
-        if (m === 'ron') randomPose(1); // swap to randomPose() if you want a surprise
-      }
-    });
-
-    function titleUpdate(m){
-      const t = document.getElementById('titleSwap');
-      const r = document.getElementById('titleRight');
-      t.textContent = (m==='lucy')   ? 'Pebbles and Things'
-                   : (m==='coffee') ? 'Receipts or whatever.'
-                                     : 'Money and Things';
-      r.textContent = (m==='lucy')   ? 'The River’s Ledger'
-                   : (m==='coffee') ? 'The Café’s Till'
-                                     : 'The Mountain’s Record';
-    }
-
-    // Only Lucy image toggles; Ron uses sprite
-    function artSwap(m){
-      const lucy = document.getElementById('lucyArt');
-      if (!lucy) return;
-      lucy.style.display = (m==='lucy') ? '' : 'none';
-    }
-
-    // Settings
-    const reservePctInput = document.getElementById('reservePct');
-    const saveSettingsBtn  = document.getElementById('saveSettings');
-    reservePctInput.value  = store.loadSettings().reservePct;
-    saveSettingsBtn.addEventListener('click', ()=>{
-      const v = Number(reservePctInput.value);
-      const pct = isNaN(v) || v < 0 ? 0 : Math.min(100, v);
-      const s = store.loadSettings(); s.reservePct = pct; store.saveSettings(s);
-      paint();
-    });
-
-    // Form wiring
-    const form     = document.getElementById('entryForm');
-    const clearBtn = document.getElementById('clearBtn');
-    clearBtn.addEventListener('click', ()=> form.reset());
-
-    const invoiceBtn = document.getElementById('invoiceBtn');
-    invoiceBtn.addEventListener('click', ()=>{
-      const client = prompt('Invoice for which client?');
-      if(!client) return;
-      const entries = store.loadEntries();
-      const list = entries.filter(e => (e.client||'').toLowerCase() === client.toLowerCase());
-      if(!list.length){ alert('No entries for that client.'); return; }
-      window.makeInvoice(list, client);
-    });
-
-    wireForm(form, {
-      onSubmit(entry, meta){
-        const entries = store.loadEntries();
-        if (meta.multiday.mode==='summary'){
-          entries.push(entry);
-        } else if (meta.multiday.mode==='expand'){
-          meta.multiday.expanded.forEach(e => entries.push(e));
-        } else {
-          entries.push(entry);
-        }
-        store.saveEntries(entries);
-
-        // Sparkles
-        const btn = document.getElementById('logBtn');
-        const r = btn.getBoundingClientRect();
-        const y = r.top + r.height/2 + window.scrollY;
-        sparklesBurst(r.left + r.width/2, y, current());
-
-        const saved = document.getElementById('savedMsg');
-        saved.style.display='block'; setTimeout(()=> saved.style.display='none', 1200);
-        form.reset();
-        form.date.value = new Date().toISOString().slice(0,10);
-        document.getElementById('multiFields').style.display='none';
-        document.getElementById('multiChoice').style.display='none';
-        document.getElementById('multiToggle').checked=false;
-
-        paint();
-      }
-    });
-
-    // Coffee mini
-    wireCoffeeMini(document.getElementById('coffeeMini'));
-
-    // Initial paint
-    function paint(){
-      showOnce(current());
-      const entries = store.loadEntries();
-      const reservePct = store.loadSettings().reservePct;
-      const totals = renderTable(document.getElementById('rows'), entries, reservePct);
-      renderSummaries(entries, reservePct, totals);
-    }
-    paint();
-  </script>
-
-  <!-- BACKUP MODULE -->
-  <script src="ui/backup.js" defer></script>
 </body>
 </html>

--- a/swirl-system/css/base.css
+++ b/swirl-system/css/base.css
@@ -1,33 +1,68 @@
+/* Swirlface Core Palette — Jonah v1 (photo-derived) */
+/* neutrals */
+:root{
+  --ink: #1B1F33;
+  --ink-soft: #3A3F57;
+  --paper: #FAF7F2;      /* warm off-white background */
+  --veil: rgba(255,255,255,0.7);
+
+  /* pillar anchors */
+  --pillar-spiritual: #CFA9F2;  /* soft lilac (Spiritual Routine) */
+  --pillar-family:    #F2C156;  /* warm honey gold */
+  --pillar-self:      #CFE8DF;  /* seafoam/minty */
+  --pillar-rrr:       #BFD7F6;  /* sky blue */
+  --pillar-work:      #FFB38A;  /* peach/apricot */
+
+  /* supportive pastels from the photo */
+  --pastel-pink:   #F7B3C8;
+  --pastel-lilac:  #D9A7E1;
+  --pastel-peach:  #FFC29B;
+  --pastel-butter: #F7E5A3;
+  --pastel-sky:    #A7C7E7;
+
+  /* UI accents (IG-ish) */
+  --chip-fill: #FFFFFF;
+  --chip-border: #DFE3F3;
+  --chip-active: #F4F7FF;
+  --chip-accent: #EAF0FF;
+
+  /* gradients used for hero text / buttons */
+  --grad-hero: linear-gradient(180deg, #AFC8FF 0%, #D9A7E1 100%);
+  --grad-like: linear-gradient(135deg, #FF8FB2 0%, #FFB38A 100%);
+  --grad-save: linear-gradient(135deg, #B2F0E6 0%, #BFD7F6 100%);
+}
+
+/* Pillar utility classes */
+.pillar--spiritual { --pillar: var(--pillar-spiritual); }
+.pillar--family    { --pillar: var(--pillar-family); }
+.pillar--self      { --pillar: var(--pillar-self); }
+.pillar--rrr       { --pillar: var(--pillar-rrr); }
+.pillar--work      { --pillar: var(--pillar-work); }
+
 body {
   font-family: sans-serif;
   margin: 0;
   padding: 20px;
-  background-color: #f8f8f8;
-  color: #333;
+  background: var(--paper);
+  color: var(--ink);
 }
 
-form {
-  margin-bottom: 20px;
-}
+form { margin-bottom: 20px; }
 
-label {
-  display: block;
-  margin-top: 10px;
-}
+label { display: block; margin-top: 10px; }
 
 input,
 select,
-textarea {
+textarea,
+button {
   width: 100%;
   padding: 8px;
   margin-top: 4px;
   box-sizing: border-box;
+  font: inherit;
 }
 
-#crumb-list {
-  list-style: none;
-  padding: 0;
-}
+#crumb-list { list-style: none; padding: 0; }
 
 #crumb-list li {
   background: #fff;
@@ -43,11 +78,10 @@ textarea {
   margin-bottom: 5px;
 }
 
-:root { --bg:#0d0f12; --fg:#f6f7fb; --accent:#8ae; }
-body { margin:0; background:var(--bg); color:var(--fg); font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
-label { display:grid; gap:6px; margin:10px 0; }
-input, select, textarea, button { font: inherit; }
-.thumb { width:100%; max-height: 260px; object-fit: cover; border-radius: 10px; border:1px solid #22283a; }
-.crumb { background:#111520; border:1px solid #22283a; border-radius:12px; padding:10px; margin:10px 0; }
-.crumb .head { display:flex; justify-content:space-between; color:#9fb0c6; margin-bottom:8px; }
+.thumb { width:100%; max-height: 260px; object-fit: cover; border-radius: 10px; border:1px solid var(--chip-border); }
+
+.crumb {
+  background:#fff; border:1px solid #ECEFF7; border-radius:12px; padding:10px; margin:10px 0;
+}
+.crumb .head { display:flex; justify-content:space-between; color:var(--ink-soft); margin-bottom:8px; }
 .hidden { display:none !important; }

--- a/swirl-system/css/swirlfeed.css
+++ b/swirl-system/css/swirlfeed.css
@@ -10,3 +10,17 @@
 .meta .open-day { background:#8ae; color:#0c1020; border:none; padding:6px 10px; border-radius:10px; cursor:pointer; }
 .meta .fav { background:transparent; color:#9fb0c6; border:1px solid #2a2f40; padding:6px 10px; border-radius:10px; cursor:pointer; }
 .meta .fav.faved { color:#ff8ac5; border-color:#ff8ac5; }
+
+/* New palette styles */
+.feed-body { background: var(--paper); color: var(--ink); }
+.feed { background: var(--paper); color: var(--ink); }
+.post-card{
+  background:#fff; border:1px solid #ECEFF7; border-radius:16px; padding:12px;
+  box-shadow:0 8px 24px rgba(0,0,0,.06); margin:10px auto; max-width:720px;
+}
+.post-card .post-actions button.like{
+  background: var(--grad-like); color:#fff; border:none; border-radius:12px; padding:8px 12px;
+}
+.post-card .post-actions button.save{
+  background: var(--grad-save); color:#0d2933; border:none; border-radius:12px; padding:8px 12px;
+}

--- a/swirl-system/data/honeycomb.json
+++ b/swirl-system/data/honeycomb.json
@@ -1,10 +1,10 @@
 [
   { "pillar": "📚 RRR", "idea": "Draw Nebuchadnezzar’s statue with labeled sections." },
   { "pillar": "📚 RRR", "idea": "Place the 7 world powers on a simple timeline." },
-  { "pillar": "👑 Divine", "idea": "Find 1 verse from Daniel that mentions a world power and copy it neatly." },
+  { "pillar": "👑 Spiritual Routine", "idea": "Find 1 verse from Daniel that mentions a world power and copy it neatly." },
   { "pillar": "📚 RRR", "idea": "Match each world power to its symbol (lion, bear, leopard…)." },
-  { "pillar": "👑 Divine", "idea": "Write a one-sentence prayer about staying faithful under pressure like Daniel." },
+  { "pillar": "👑 Spiritual Routine", "idea": "Write a one-sentence prayer about staying faithful under pressure like Daniel." },
   { "pillar": "📚 RRR", "idea": "Color a world map and mark Babylon, Medo-Persia, Greece, Rome." },
   { "pillar": "📚 RRR", "idea": "Explain the 'Politically Divided Toes' in your own words (1-2 sentences)." },
-  { "pillar": "👑 Divine", "idea": "Pick one modern news story and ask: how do we stay neutral and faithful today?" }
+  { "pillar": "👑 Spiritual Routine", "idea": "Pick one modern news story and ask: how do we stay neutral and faithful today?" }
 ]

--- a/swirl-system/feed.html
+++ b/swirl-system/feed.html
@@ -19,17 +19,17 @@
   <main id="feed" class="feed"></main>
 
   <template id="postTpl">
-    <article class="post">
+    <article class="post-card">
       <div class="post-head">
         <span class="pillar"></span>
         <span class="date"></span>
       </div>
       <div class="media"></div>
       <p class="text"></p>
-      <div class="meta">
+      <div class="post-actions">
         <span class="parts"></span>
-        <button class="open-day">Open Day</button>
-        <button class="fav">♡</button>
+        <button class="like">Like</button>
+        <button class="save">Save</button>
       </div>
     </article>
   </template>

--- a/swirl-system/index.html
+++ b/swirl-system/index.html
@@ -16,7 +16,7 @@
     <form id="crumbForm">
       <label>Pillar
         <select id="pillar">
-          <option>👑 Divine</option>
+          <option>👑 Spiritual Routine</option>
           <option>🏡 Family</option>
           <option>🌱 Self+Parts</option>
           <option>📚 RRR</option>
@@ -32,25 +32,50 @@
         <input id="photo" type="file" accept="image/*" />
       </label>
 
-      <!-- Starter Parts/Feelings/Needs + Real-life tag + Micro-goal -->
-      <div id="extras"></div>
+      <label>Part who showed up
+        <select name="part">
+          <option value="">— optional —</option>
+          <option>Curious</option><option>Tired</option><option>Brave</option>
+          <option>Helper</option><option>Playful</option>
+        </select>
+      </label>
+
+      <label>Feeling
+        <select name="feeling">
+          <option value="">— optional —</option>
+          <option>Calm</option><option>Happy</option><option>Frustrated</option>
+          <option>Anxious</option><option>Proud</option>
+        </select>
+      </label>
+
+      <details class="goal-block"><summary>Set a tiny skill goal?</summary>
+        <label>Skill <input name="goalSkill" placeholder="e.g., make a pet-flyer"></label>
+        <label>Next step <input name="goalNext" placeholder="print one draft"></label>
+        <label>Helper part
+          <select name="goalHelper">
+            <option value="">— choose —</option>
+            <option>Curious</option><option>Tired</option><option>Brave</option>
+            <option>Helper</option><option>Playful</option>
+          </select>
+        </label>
+      </details>
 
       <button type="submit">Save</button>
     </form>
 
     <section id="swirl-feed" class="feed"></section>
     <template id="postTpl">
-      <article class="post">
+      <article class="post-card">
         <div class="post-head">
           <span class="pillar"></span>
           <span class="date"></span>
         </div>
         <div class="media"></div>
         <p class="text"></p>
-        <div class="meta">
+        <div class="post-actions">
           <span class="parts"></span>
-          <button class="open-day">Open Day</button>
-          <button class="fav">♡</button>
+          <button class="like">Like</button>
+          <button class="save">Save</button>
         </div>
       </article>
     </template>

--- a/swirl-system/js/crumb-entry.js
+++ b/swirl-system/js/crumb-entry.js
@@ -1,16 +1,17 @@
-// Phase 1+ : Drop-a-crumb (photo, text, pillar) + starter Parts/Feelings/Needs + optional micro-goal prompt
+// Phase 1+ : Drop-a-crumb (photo, text, pillar) + starter Parts/Feelings + optional micro-goal prompt
 import { load, save } from './storage.js';
 
 const KEY = 'crumbs';
 
 const PILLAR_LABELS = {
-  'divine':'👑 Divine', 'family':'🏡 Family', 'self':'🌱 Self+Parts', 'rrr':'📚 RRR', 'work':'💵 Earning',
-  '👑 Divine':'👑 Divine','🏡 Family':'🏡 Family','🌱 Self+Parts':'🌱 Self+Parts','📚 RRR':'📚 RRR','💵 Earning':'💵 Earning'
+  'divine':'👑 Spiritual Routine', 'family':'🏡 Family', 'self':'🌱 Self+Parts', 'rrr':'📚 RRR', 'work':'💵 Earning',
+  '👑 Spiritual Routine':'👑 Spiritual Routine','🏡 Family':'🏡 Family','🌱 Self+Parts':'🌱 Self+Parts','📚 RRR':'📚 RRR','💵 Earning':'💵 Earning'
 };
 
-const feelings = ['Happy','Sad','Tired','Calm','Excited'];
-const needs    = ['Rest','Play','Help','Comfort','Space'];
-const parts    = ['Otter','Ron','Lucy','Glimmer'];
+const STARTER_PARTS = ["Curious", "Tired", "Brave", "Helper", "Playful"];
+const STARTER_FEELINGS = ["Calm","Happy","Frustrated","Anxious","Proud"];
+// Goal fields minimal:
+const GOAL_FIELDS = ["Skill","Next step","Helper part"];
 
 function qs(id){ return document.getElementById(id); }
 function renderList(){
@@ -24,7 +25,6 @@ function renderList(){
     const meta = [
       c.part ? `Part: ${c.part}` : '',
       c.feeling ? `Feeling: ${c.feeling}` : '',
-      c.need ? `Need: ${c.need}` : '',
       c.goal?.skill ? `Goal: ${c.goal.skill} → ${c.goal.nextStep}` : ''
     ].filter(Boolean).join(' · ');
     return `<li class="crumb">
@@ -51,38 +51,6 @@ window.addEventListener('DOMContentLoaded', ()=>{
   const textEl = qs('text');
   const photoEl = qs('photo');
 
-  // Inject starter selects if not present
-  const extras = qs('extras');
-  if (extras && !qs('feeling')){
-    extras.innerHTML = `
-      <label>Feeling (optional)
-        <select id="feeling"><option value="">—</option>${feelings.map(x=>`<option>${x}</option>`).join('')}</select>
-      </label>
-      <label>Need (optional)
-        <select id="need"><option value="">—</option>${needs.map(x=>`<option>${x}</option>`).join('')}</select>
-      </label>
-      <label>Part (optional)
-        <select id="part"><option value="">—</option>${parts.map(x=>`<option>${x}</option>`).join('')}</select>
-      </label>
-      <label>Real-life tag (optional)
-        <select id="reallife"><option value="">—</option><option>🐾 Pet Call</option><option>🧻 Toilet Time</option></select>
-      </label>
-      <div id="goalWrap" class="goal hidden">
-        <h3>Micro Goal</h3>
-        <label>Skill <input id="goalSkill" placeholder="e.g., Responsibility"/></label>
-        <label>Next step <input id="goalNext" placeholder="e.g., Carry wipes & count pets"/></label>
-        <label>Helper part
-          <select id="goalPart"><option value="">—</option>${parts.map(x=>`<option>${x}</option>`).join('')}</select>
-        </label>
-      </div>
-    `;
-  }
-
-  // Show/hide micro-goal when a real-life tag is chosen
-  qs('reallife')?.addEventListener('change', e=>{
-    qs('goalWrap')?.classList.toggle('hidden', !e.target.value);
-  });
-
   form?.addEventListener('submit', async (e)=>{
     e.preventDefault();
     const text   = textEl.value.trim();
@@ -97,29 +65,23 @@ window.addEventListener('DOMContentLoaded', ()=>{
       pillar,
       text,
       photo: photo || null,
-      feeling: qs('feeling')?.value || '',
-      need: qs('need')?.value || '',
-      part: qs('part')?.value || '',
+      part: form.elements['part']?.value || '',
+      feeling: form.elements['feeling']?.value || ''
     };
 
-    // attach micro-goal if visible
-    if (!qs('goalWrap')?.classList.contains('hidden')){
-      const skill = qs('goalSkill').value.trim();
-      const next  = qs('goalNext').value.trim();
-      const gpart = qs('goalPart').value.trim();
-      if (skill || next || gpart){
-        crumb.goal = { skill, nextStep: next, part: gpart };
-      }
+    const skill = form.elements['goalSkill']?.value.trim();
+    const next  = form.elements['goalNext']?.value.trim();
+    const helper = form.elements['goalHelper']?.value.trim();
+    if (skill || next || helper){
+      crumb.goal = { skill, nextStep: next, helper };
     }
 
-      data.push(crumb);
-      save(KEY, data);
-      document.dispatchEvent(new Event('crumbsChanged'));
-      form.reset();
-      // hide goal wrap again
-      qs('goalWrap')?.classList.add('hidden');
-      renderList();
-    });
+    data.push(crumb);
+    save(KEY, data);
+    document.dispatchEvent(new Event('crumbsChanged'));
+    form.reset();
+    renderList();
+  });
 
   renderList();
 });

--- a/swirl-system/js/swirlfeed.js
+++ b/swirl-system/js/swirlfeed.js
@@ -3,13 +3,13 @@ import { load } from './storage.js';
 const KEY = 'crumbs';
 
 const PILLAR_ICON = {
-  '👑 Divine':'👑 Divine',
+  '👑 Spiritual Routine':'👑 Spiritual Routine',
   '🏡 Family':'🏡 Family',
   '🌱 Self+Parts':'🌱 Self+Parts',
   '📚 RRR':'📚 RRR',
   '💵 Earning':'💵 Earning',
   // also support old internal codes if any
-  'divine':'👑 Divine','family':'🏡 Family','self':'🌱 Self+Parts','rrr':'📚 RRR','work':'💵 Earning'
+  'divine':'👑 Spiritual Routine','family':'🏡 Family','self':'🌱 Self+Parts','rrr':'📚 RRR','work':'💵 Earning'
 };
 
 const feed = document.getElementById('swirl-feed') || document.getElementById('feed');
@@ -43,12 +43,11 @@ function render(){
       media.appendChild(img);
     }
 
-    node.querySelector('.open-day').addEventListener('click',()=>{
-      // pass date via query param so day view groups all crumbs from that day
+    node.querySelector('.save').addEventListener('click',()=>{
       location.href = `./day.html?d=${encodeURIComponent(ymd(c.date))}`;
     });
 
-    node.querySelector('.fav').addEventListener('click', (e)=>{
+    node.querySelector('.like').addEventListener('click', (e)=>{
       e.currentTarget.classList.toggle('faved');
     });
 


### PR DESCRIPTION
## Summary
- Introduce Jonah's Swirl School landing with sticky mode tabs, hero header, decorative bubbles, and spiral center
- Apply photo-derived palette tokens and utility classes, extend entry form with part/feeling/goal fields
- Restyle SwirlFeed cards and actions with friendly gradients and update pillar copy to "Spiritual Routine"

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c3bed578832e95649c5fe70ab814