### PR TITLE
Ensure Jonah Swirl School assets load

### DIFF
--- a/jonah-swirl-school/day.html
+++ b/jonah-swirl-school/day.html
@@ -6,6 +6,7 @@
   <title>Drop a Crumb · Jonah</title>
   <link rel="stylesheet" href="./css/base.css">
   <link rel="stylesheet" href="./css/day.css">
+  <link rel="stylesheet" href="./css/settings.css">
 </head>
 <body>
   <!-- DAY VIEW / ENTRY -->
@@ -171,7 +172,6 @@
     renderList();
     renderSchedule();
   </script>
-  <link rel="stylesheet" href="./css/settings.css">
   <script type="module" src="./js/settings.js"></script>
   <script type="module">
     // Wire settings button

--- a/jonah-swirl-school/index.html
+++ b/jonah-swirl-school/index.html
@@ -4,7 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Jonah Swirl — Home</title>
-  <link rel="stylesheet" href="css/hub.css">
+  <link rel="stylesheet" href="./css/base.css">
+  <link rel="stylesheet" href="./css/hub.css">
 </head>
 <body class="mode-swirl">
   <!-- MODE TOGGLES -->
@@ -46,6 +47,6 @@
     <div class="sparkles" aria-hidden="true"></div>
   </main>
 
-  <script src="js/hub.js"></script>
+  <script src="./js/hub.js"></script>
 </body>
 </html>

--- a/jonah-swirl-school/weekly.html
+++ b/jonah-swirl-school/weekly.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="./css/base.css">
   <link rel="stylesheet" href="./css/weekly.css">
   <link rel="stylesheet" href="./css/blooms.css">
+  <link rel="stylesheet" href="./css/settings.css">
 </head>
 <body>
   <main class="wrap">
@@ -56,7 +57,6 @@
   <script type="module" src="./js/blooms.js"></script>
   <script type="module" src="./js/export.js"></script>
   <script type="module" src="./js/settings.js"></script>
-  <link rel="stylesheet" href="./css/settings.css">
   <script type="module">
     import { weekWindow, summarizeWeek, renderPillarBars, renderBlooms, gotoWeek, isoLabel } from './js/blooms.js';
     import { downloadJson, downloadCsv } from './js/export.js';


### PR DESCRIPTION
## Summary
- Add `base.css` and correct JS/CSS paths on Jonah Swirl home
- Move settings stylesheet into the head for Day and Weekly pages

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d3501de0832ea21c00de25980a6c