### PR TITLE
Fix Swirl School styling and navigation

### DIFF
--- a/assets/swirl.svg
+++ b/assets/swirl.svg
@@ -1,5 +1,5 @@
 <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" aria-label="Swirl">
   <title>Met, Not Grabbed</title>
-  <path d="M454 274c0 115-93 208-208 208S38 389 38 274 131 66 246 66c82 0 149 67 149 149 0 58-47 105-105 105-46 0-83-37-83-83 0-35 28-63 63-63 27 0 49 22 49 49"
-        fill="none" stroke="#4F6F5F" stroke-width="18" stroke-linecap="round"/>
+   <path d="M454 274c0 115-93 208-208 208S38 389 38 274 131 66 246 66c82 0 149 67 149 149 0 58-47 105-105 105-46 0-83-37-83-83 0-35 28-63 63-63 27 0 49 22 49 49"
+         fill="none" stroke="currentColor" stroke-width="18" stroke-linecap="round"/>
 </svg>

--- a/css/home.css
+++ b/css/home.css
@@ -59,6 +59,7 @@ body { background: var(--paper); color: var(--ink); }
 
 .hero{
   position: relative; z-index: 10; padding: clamp(12px,4vw,24px) 16px 8px; text-align:center;
+  margin-top:72px;
 }
 .hero-title{ margin:0 auto; max-width:22ch; line-height:1.1; display:grid; gap:6px; }
 .hero-kicker{
@@ -90,5 +91,6 @@ body { background: var(--paper); color: var(--ink); }
   position: relative; z-index: 5; display: grid; place-items:center;
   margin: clamp(12px, 6vw, 40px) auto; width:min(240px, 60vw);
   aspect-ratio:1/1; opacity:.9;
+  color:#6e5fbf;
 }
 .center-swirl img{ width:100%; height:100%; }

--- a/index.html
+++ b/index.html
@@ -11,8 +11,9 @@
 <!-- TOP NAV TABS -->
 <nav class="swirl-tabs" aria-label="Modes">
   <button class="tab is-active" onclick="location.href='/'" aria-current="page">Swirlface</button>
-  <button class="tab" onclick="location.href='/structured.html'">Structured</button>
-  <button class="tab accent" onclick="location.href='/jonah-swirl-school/index.html'">Drop a crumb</button>
+  <button class="tab" onclick="location.href='jonah-swirl-school/index.html#structured'">Structured</button>
+  <button class="tab" onclick="location.href='jonah-swirl-school/swirlfeed.html'">Feed</button>
+  <button class="tab accent" onclick="location.href='jonah-swirl-school/index.html'">Drop a crumb</button>
 </nav>
 
 <!-- HERO TITLE (mobile-safe) -->
@@ -34,7 +35,7 @@
 
 <!-- CENTER SWIRL -->
 <div class="center-swirl">
-  <img src="/assets/swirl.svg" alt="Swirl — Met, Not Grabbed">
+  <img src="assets/swirl.svg" alt="Swirl — Met, Not Grabbed">
 </div>
 
 </body>

--- a/jonah-swirl-school/css/hub.css
+++ b/jonah-swirl-school/css/hub.css
@@ -64,7 +64,7 @@ body{
 
 .site-banner{
   position:absolute;
-  top:40px; left:50%; transform:translateX(-50%);
+  top:120px; left:50%; transform:translateX(-50%);
   text-align:center;
   z-index:6; pointer-events:none;
 }

--- a/jonah-swirl-school/js/hub.js
+++ b/jonah-swirl-school/js/hub.js
@@ -57,8 +57,9 @@ crumbBox?.addEventListener('change', () => {
   }
 });
 
-// start in Swirlface mode
-setMode('swirl');
+// start in mode based on hash (#structured) or default to Swirlface
+const initialMode = location.hash === '#structured' ? 'structured' : 'swirl';
+setMode(initialMode);
 
 // draw smooth spiral
 function makeSpiralPath({cx=100, cy=100, startR=5, spacing=4, turns=4, steps=360}={}){


### PR DESCRIPTION
## Summary
- load swirl SVG with themeable color and relative path
- add missing Feed tab and correct Structured link
- adjust banners to avoid toolbar overlap and enable structured mode via URL hash

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6dc5ca614832e856ae04002b0e842