### PR TITLE
Add cache busting to Jonah Swirl School assets

### DIFF
--- a/jonah-swirl-school/day.html
+++ b/jonah-swirl-school/day.html
@@ -4,9 +4,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Drop a Crumb · Jonah</title>
-  <link rel="stylesheet" href="./css/base.css">
-  <link rel="stylesheet" href="./css/day.css">
-  <link rel="stylesheet" href="./css/settings.css">
+  <link rel="stylesheet" href="./css/base.css?v=jonah-1">
+  <link rel="stylesheet" href="./css/day.css?v=jonah-1">
+  <link rel="stylesheet" href="./css/settings.css?v=jonah-1">
 </head>
 <body>
   <!-- DAY VIEW / ENTRY -->
@@ -68,10 +68,10 @@
     </section>
   </main>
 
-  <script type="module" src="./js/storage.js"></script>
-  <script type="module" src="./js/crumb-entry.js"></script>
-  <script type="module" src="./js/pin.js"></script>
-  <script type="module" src="./js/photos.js"></script>
+  <script type="module" src="./js/storage.js?v=jonah-1"></script>
+  <script type="module" src="./js/crumb-entry.js?v=jonah-1"></script>
+  <script type="module" src="./js/pin.js?v=jonah-1"></script>
+  <script type="module" src="./js/photos.js?v=jonah-1"></script>
   <script type="module">
     import { initSync } from './js/sync.js';
     // Start listening to storage events for optional sync.
@@ -172,7 +172,7 @@
     renderList();
     renderSchedule();
   </script>
-  <script type="module" src="./js/settings.js"></script>
+  <script type="module" src="./js/settings.js?v=jonah-1"></script>
   <script type="module">
     // Wire settings button
     document.getElementById('openSettings')?.addEventListener('click', ()=> window.openSettings && window.openSettings());

--- a/jonah-swirl-school/evidence.html
+++ b/jonah-swirl-school/evidence.html
@@ -4,9 +4,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Evidence Pack · Jonah</title>
-  <link rel="stylesheet" href="./css/base.css">
-  <link rel="stylesheet" href="./css/evidence.css">
-  <link rel="stylesheet" href="./css/blooms.css">
+  <link rel="stylesheet" href="./css/base.css?v=jonah-1">
+  <link rel="stylesheet" href="./css/evidence.css?v=jonah-1">
+  <link rel="stylesheet" href="./css/blooms.css?v=jonah-1">
 </head>
 <body>
   <main class="wrap">
@@ -42,8 +42,8 @@
     </footer>
   </main>
 
-  <script type="module" src="./js/storage.js"></script>
-  <script type="module" src="./js/blooms.js"></script>
+  <script type="module" src="./js/storage.js?v=jonah-1"></script>
+  <script type="module" src="./js/blooms.js?v=jonah-1"></script>
   <script type="module">
     import { weekWindow, summarizeWeek, renderPillarBars, renderBlooms, isoLabel } from './js/blooms.js';
     import { listCrumbs } from './js/storage.js';

--- a/jonah-swirl-school/grandma-plan.html
+++ b/jonah-swirl-school/grandma-plan.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Grandma Plan · Jonah (Upcoming)</title>
-  <link rel="stylesheet" href="./css/base.css">
-  <link rel="stylesheet" href="./css/grandma-plan.css">
+  <link rel="stylesheet" href="./css/base.css?v=jonah-1">
+  <link rel="stylesheet" href="./css/grandma-plan.css?v=jonah-1">
 </head>
 <body>
   <main class="wrap">
@@ -70,9 +70,9 @@
   </main>
 
   <!-- SCRIPTS -->
-  <script type="module" src="./js/storage.js"></script>
-  <script type="module" src="./js/blooms.js"></script>
-  <script type="module" src="./js/planner.js"></script>
+  <script type="module" src="./js/storage.js?v=jonah-1"></script>
+  <script type="module" src="./js/blooms.js?v=jonah-1"></script>
+  <script type="module" src="./js/planner.js?v=jonah-1"></script>
   <script type="module">
     import { initPlanner } from './js/planner.js';
     initPlanner();

--- a/jonah-swirl-school/grandma.html
+++ b/jonah-swirl-school/grandma.html
@@ -4,9 +4,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Grandma Recap · Jonah</title>
-  <link rel="stylesheet" href="./css/base.css">
-  <link rel="stylesheet" href="./css/weekly.css">
-  <link rel="stylesheet" href="./css/blooms.css">
+  <link rel="stylesheet" href="./css/base.css?v=jonah-1">
+  <link rel="stylesheet" href="./css/weekly.css?v=jonah-1">
+  <link rel="stylesheet" href="./css/blooms.css?v=jonah-1">
 </head>
 <body>
   <main class="wrap">
@@ -49,9 +49,9 @@
     </section>
   </main>
 
-  <script type="module" src="./js/storage.js"></script>
-  <script type="module" src="./js/blooms.js"></script>
-  <script type="module" src="./js/export.js"></script>
+  <script type="module" src="./js/storage.js?v=jonah-1"></script>
+  <script type="module" src="./js/blooms.js?v=jonah-1"></script>
+  <script type="module" src="./js/export.js?v=jonah-1"></script>
   <script type="module">
     import { weekWindow, summarizeWeek, renderPillarBars, renderBlooms, isoLabel } from './js/blooms.js';
     import { downloadJson, downloadCsv } from './js/export.js';

--- a/jonah-swirl-school/index.html
+++ b/jonah-swirl-school/index.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Jonah Swirl — Home</title>
-  <link rel="stylesheet" href="./css/base.css">
-  <link rel="stylesheet" href="./css/hub.css">
+  <link rel="stylesheet" href="./css/base.css?v=jonah-1">
+  <link rel="stylesheet" href="./css/hub.css?v=jonah-1">
 </head>
 <body class="mode-swirl">
   <!-- MODE TOGGLES -->
@@ -47,6 +47,6 @@
     <div class="sparkles" aria-hidden="true"></div>
   </main>
 
-  <script src="./js/hub.js"></script>
+  <script src="./js/hub.js?v=jonah-1"></script>
 </body>
 </html>

--- a/jonah-swirl-school/swirlfeed.html
+++ b/jonah-swirl-school/swirlfeed.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Swirlfeed · Jonah</title>
-  <link rel="stylesheet" href="./css/base.css">
-  <link rel="stylesheet" href="./css/swirlfeed.css">
+  <link rel="stylesheet" href="./css/base.css?v=jonah-1">
+  <link rel="stylesheet" href="./css/swirlfeed.css?v=jonah-1">
 </head>
 <body>
   <main class="wrap">
@@ -37,7 +37,7 @@
   </main>
 
   <!-- Scripts -->
-  <script type="module" src="./js/storage.js"></script>
-  <script type="module" src="./js/swirlfeed.js"></script>
+  <script type="module" src="./js/storage.js?v=jonah-1"></script>
+  <script type="module" src="./js/swirlfeed.js?v=jonah-1"></script>
 </body>
 </html>

--- a/jonah-swirl-school/weekly.html
+++ b/jonah-swirl-school/weekly.html
@@ -4,10 +4,10 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Weekly Glow · Jonah</title>
-  <link rel="stylesheet" href="./css/base.css">
-  <link rel="stylesheet" href="./css/weekly.css">
-  <link rel="stylesheet" href="./css/blooms.css">
-  <link rel="stylesheet" href="./css/settings.css">
+  <link rel="stylesheet" href="./css/base.css?v=jonah-1">
+  <link rel="stylesheet" href="./css/weekly.css?v=jonah-1">
+  <link rel="stylesheet" href="./css/blooms.css?v=jonah-1">
+  <link rel="stylesheet" href="./css/settings.css?v=jonah-1">
 </head>
 <body>
   <main class="wrap">
@@ -53,10 +53,10 @@
     </section>
   </main>
 
-  <script type="module" src="./js/storage.js"></script>
-  <script type="module" src="./js/blooms.js"></script>
-  <script type="module" src="./js/export.js"></script>
-  <script type="module" src="./js/settings.js"></script>
+  <script type="module" src="./js/storage.js?v=jonah-1"></script>
+  <script type="module" src="./js/blooms.js?v=jonah-1"></script>
+  <script type="module" src="./js/export.js?v=jonah-1"></script>
+  <script type="module" src="./js/settings.js?v=jonah-1"></script>
   <script type="module">
     import { weekWindow, summarizeWeek, renderPillarBars, renderBlooms, gotoWeek, isoLabel } from './js/blooms.js';
     import { downloadJson, downloadCsv } from './js/export.js';


### PR DESCRIPTION
## Summary
- Append `?v=jonah-1` to CSS and JS references across Jonah Swirl School pages to prevent stale caching

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6de79b36c832ea083f1f1d94400c1