### PR TITLE
Refine Swirl School layout and add contextual guidance

### DIFF
--- a/jonah-swirl-school/css/base.css
+++ b/jonah-swirl-school/css/base.css
@@ -2,9 +2,20 @@
   /* Core palette from swirl-system */
   --ink: #1B1F33;
   --ink-soft: #3A3F57;
+  --ink-mist: #555a70;
+  --ink-faint: #7c829c;
   --paper: #FAF7F2;      /* warm off-white background */
   --bg: var(--paper);    /* maintain existing var name */
   --veil: rgba(255,255,255,0.7);
+
+  /* translucent surface tones */
+  --surface: rgba(255,255,255,0.92);
+  --surface-strong: rgba(255,255,255,0.96);
+  --surface-soft: rgba(255,255,255,0.82);
+  --border-soft: rgba(27,31,51,0.08);
+  --border-strong: rgba(27,31,51,0.12);
+  --halo-mint: rgba(143,213,196,0.28);
+  --halo-pink: rgba(255,157,216,0.22);
 
   /* pillar anchors */
   --pillar-spiritual: #CFA9F2;  /* soft lilac (Spiritual Routine) */
@@ -12,6 +23,11 @@
   --pillar-self:      #CFE8DF;  /* seafoam/minty */
   --pillar-rrr:       #BFD7F6;  /* sky blue */
   --pillar-work:      #FFB38A;  /* peach/apricot */
+  --p-divine-100: rgba(207,169,242,0.22);
+  --p-family-100: rgba(242,193,86,0.22);
+  --p-self-100:   rgba(207,232,223,0.35);
+  --p-rrr-100:    rgba(191,215,246,0.32);
+  --p-work-100:   rgba(255,179,138,0.30);
 
   /* supportive pastels from the photo */
   --pastel-pink:   #F7B3C8;
@@ -42,7 +58,8 @@
   --grad-like: linear-gradient(135deg, #FF8FB2 0%, #FFB38A 100%);
   --grad-save: linear-gradient(135deg, #B2F0E6 0%, #BFD7F6 100%);
 
-  --shadow: rgba(0,0,0,0.12);
+  --shadow: rgba(0,0,0,0.14);
+  --shadow-strong: rgba(0,0,0,0.18);
   --radius: 18px;
 
   /* Jonah-friendly sizes */
@@ -53,11 +70,81 @@
 html,body{height:100%}
 body{
   margin:0;
-  background: var(--bg);
+  background-color: var(--bg);
   color: var(--ink);
   font-family: ui-rounded, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
-  line-height: 1.45;
+  line-height: 1.5;
+}
+
+body:not(.mode-swirl){
+  background-image:
+    radial-gradient(1200px 820px at 12% -10%, rgba(255,177,207,0.32), transparent 58%),
+    radial-gradient(900px 900px at 88% 0%, rgba(181,211,255,0.28), transparent 58%),
+    radial-gradient(1200px 820px at 50% 120%, rgba(143,213,196,0.22), transparent 65%);
+  background-attachment: fixed;
+}
+
+a{
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover{ text-decoration: underline; text-decoration-color: rgba(27,31,51,0.35); }
+
+.page-shell{
+  width: min(960px, 94vw);
+  margin: 0 auto;
+  padding: clamp(16px, 4vw, 32px) clamp(18px, 4vw, 36px) clamp(54px, 9vw, 88px);
+}
+
+.page-head{
+  display:flex;
+  align-items:center;
+  gap: clamp(10px, 2.6vw, 18px);
+  flex-wrap: wrap;
+  margin-bottom: clamp(12px, 3vw, 26px);
+}
+
+.page-head h1{
+  margin:0;
+  font-size: clamp(22px, 4.4vw, 32px);
+  letter-spacing: 0.5px;
+}
+
+.page-head .spacer{ flex:1 1 auto; }
+
+.page-intro{
+  margin: clamp(4px, 1.4vw, 12px) 0 clamp(16px, 4vw, 28px);
+  padding: 0.85rem 1rem;
+  border-radius: 18px;
+  background: rgba(27,31,51,0.06);
+  border: 1px dashed rgba(27,31,51,0.12);
+  color: var(--ink-mist);
+  font-size: clamp(0.95rem, 2.5vw, 1.05rem);
+  line-height: 1.6;
+}
+
+body.mode-swirl .page-intro{
+  background: rgba(255,255,255,0.68);
+  border-color: rgba(255,255,255,0.5);
+  color: rgba(33,35,52,0.82);
+}
+
+.card{
+  background: var(--surface-strong);
+  border-radius: var(--radius);
+  border: 1.5px solid var(--border-soft);
+  box-shadow: 0 22px 55px -32px var(--shadow-strong);
+  padding: clamp(16px, 3vw, 24px);
+  margin: clamp(16px, 3.2vw, 28px) 0;
+  backdrop-filter: blur(8px);
+  transition: transform .2s ease, box-shadow .2s ease;
+}
+
+.card:hover{
+  transform: translateY(-2px);
+  box-shadow: 0 28px 64px -30px rgba(27,31,51,0.26);
 }
 
 .btn{
@@ -65,20 +152,33 @@ body{
   padding: .8rem 1.1rem;
   min-height: var(--tap);
   border-radius: 14px;
-  background: var(--accent3);
-  color: #fff;
+  background: linear-gradient(135deg, var(--accent3), #ffcc4b);
+  color: #382600;
   text-decoration: none;
-  box-shadow: 0 6px 16px var(--shadow);
+  box-shadow: 0 12px 24px -12px var(--shadow);
   border: 0;
   cursor: pointer;
   font-size: 1rem;
+  font-weight: 600;
+}
+
+.btn:hover{
+  box-shadow: 0 20px 32px -18px rgba(240,188,6,0.45);
+  filter: saturate(1.05);
+  text-decoration: none;
 }
 
 .btn-big{ font-size: 1.05rem; padding: 1rem 1.2rem; }
 .btn-ghost{
-  background: rgba(255,255,255,.7);
+  background: rgba(255,255,255,.72);
   color: var(--ink);
-  border: 2px solid var(--accent1);
+  border: 2px solid rgba(143,213,196,0.6);
+  box-shadow: 0 6px 18px -12px rgba(0,0,0,0.2);
+}
+
+.btn-ghost:hover{
+  background: rgba(255,255,255,.85);
+  box-shadow: 0 16px 28px -18px rgba(143,213,196,0.6);
 }
 
 .sr-only{

--- a/jonah-swirl-school/css/day.css
+++ b/jonah-swirl-school/css/day.css
@@ -1,24 +1,18 @@
-body { margin:0; background: var(--bg); color: var(--ink); }
+body { margin:0; color: var(--ink); }
 
 .day-wrap{
-  max-width: 820px;
-  margin: 0 auto;
-  padding: clamp(14px, 3vw, 24px);
+  max-width: 880px;
+  margin: 0 auto;
 }
 
 .day-head{
-  display:flex; align-items:center; gap:12px; margin-bottom: 12px;
+  display:flex;
+  align-items:center;
+  gap: clamp(10px, 2.6vw, 18px);
 }
-.day-head h1{ margin:0; font-size: clamp(20px, 3.4vw, 26px); }
+.day-head h1{ margin:0; font-size: clamp(22px, 4vw, 30px); }
 
-.card{
-  background: rgba(255,255,255,.9);
-  border: 2px solid var(--accent1);
-  border-radius: var(--radius);
-  box-shadow: 0 10px 24px var(--shadow);
-  padding: 14px;
-  margin: 12px 0;
-}
+.day-head .btn-ghost{ backdrop-filter: blur(8px); }
 
 .row{ display:grid; grid-template-columns: 120px 1fr; gap:12px; align-items:center; margin:10px 0; }
 .lab{ opacity:.9; }
@@ -46,25 +40,36 @@ body { margin:0; background: var(--bg); color: var(--ink); }
   outline-offset:2px;
 }
 
-.hint{ opacity:.75; font-size:.92rem; margin:.35rem 0 0 0; }
+.hint{ color: var(--ink-faint); font-size:.92rem; margin:.35rem 0 0 0; }
+
+#scheduleList{
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:grid;
+  gap:6px;
+  color: var(--ink-mist);
+}
 
 input, select, textarea{
-  width:100%;
-  padding: .8rem 1rem;
-  border-radius: 12px;
-  border: 2px solid rgba(0,0,0,.06);
-  outline: none;
-  background: #fff;
-  font-size: 1rem;
+  width:100%;
+  padding: .8rem 1rem;
+  border-radius: 12px;
+  border: 1.5px solid rgba(0,0,0,.08);
+  outline: none;
+  background: #fff;
+  font-size: 1rem;
+  transition: border-color .2s ease, box-shadow .2s ease;
 }
 input:focus, select:focus, textarea:focus{
-  border-color: var(--accent1);
-  box-shadow: 0 0 0 3px rgba(143,213,196,.25);
+  border-color: rgba(143,213,196,0.8);
+  box-shadow: 0 0 0 3px rgba(143,213,196,.25);
 }
 
 #todayUl{ list-style:none; padding:0; margin:0; }
 #todayUl li{
-  padding:10px 8px; border-bottom:1px dashed rgba(0,0,0,.08);
+  padding:12px 10px;
+  border-bottom:1px dashed rgba(0,0,0,.08);
 }
 #todayUl li:last-child{ border-bottom:0; }
 /* Crumb rows + comments */

--- a/jonah-swirl-school/css/evidence.css
+++ b/jonah-swirl-school/css/evidence.css
@@ -1,17 +1,12 @@
 /* Evidence Pack – neutral print page */
-body { margin:0; background: var(--bg); color: var(--ink); }
-.wrap{ max-width: 960px; margin: 0 auto; padding: clamp(16px,3.5vw,28px); }
+body { margin:0; color: var(--ink); }
+.wrap{ max-width: 980px; margin: 0 auto; }
 
 .no-print{ display:block; }
 .head{ display:flex; gap:10px; align-items:center; }
 .head .spacer{ margin-left:auto; }
 
-.card{
-  background: #fff; border: 2px solid var(--accent1);
-  border-radius: var(--radius); box-shadow: 0 10px 24px var(--shadow);
-  padding: 16px; margin: 12px 0;
-}
-.subtle{ opacity:.8; }
+.subtle{ color: var(--ink-faint); }
 
 .bars{ display:grid; gap:10px; }
 .mini-feed{ list-style:none; margin:8px 0 0; padding:0; display:grid; gap:6px; }

--- a/jonah-swirl-school/css/grandma-plan.css
+++ b/jonah-swirl-school/css/grandma-plan.css
@@ -1,30 +1,25 @@
 /* Grandma Plan (upcoming) – neutral, print-friendly */
-body { margin:0; background: var(--bg); color: var(--ink); }
-.wrap{ max-width: 1024px; margin: 0 auto; padding: clamp(16px,3.5vw,28px); }
+body { margin:0; color: var(--ink); }
+.wrap{ max-width: 1040px; margin: 0 auto; }
 
 .no-print{ display:block; }
 .head{ display:flex; gap:10px; align-items:center; flex-wrap:wrap; margin-bottom:12px; }
 .head .spacer{ margin-left:auto; }
-
-.card{
-  background: #fff; border: 2px solid var(--accent1);
-  border-radius: var(--radius); box-shadow: 0 10px 24px var(--shadow);
-  padding: 16px; margin: 12px 0;
-}
 
 .title-card h1{ margin:0 0 6px; font-size: clamp(22px,4.2vw,34px); }
 .when{ display:flex; gap:14px; flex-wrap:wrap; margin-top:6px; }
 .when label{ display:flex; gap:8px; align-items:center; }
 
 h2{ margin:0 0 10px; font-size: clamp(18px,3.2vw,22px); }
-.hint{ opacity:.75; margin:.25rem 0 0; }
+.hint{ color: var(--ink-faint); margin:.25rem 0 0; }
 
 .plan-grid{
   overflow:auto;
   display:grid;
   grid-template-columns: 140px repeat(7, minmax(120px,1fr));
-  border:1px solid rgba(0,0,0,.08);
+  border:1px solid var(--border-soft);
   border-radius: 12px;
+  background: rgba(255,255,255,0.65);
 }
 
 .plan-grid .hdr{
@@ -32,8 +27,11 @@ h2{ margin:0 0 10px; font-size: clamp(18px,3.2vw,22px); }
   font-weight:600; padding:8px; border-bottom:1px solid rgba(0,0,0,.08);
 }
 .plan-grid .cell, .plan-grid .phdr{
-  padding:8px; border-bottom:1px solid rgba(0,0,0,.06);
-  border-right:1px dashed rgba(0,0,0,.06); min-height:44px;
+  padding:8px;
+  border-bottom:1px solid rgba(0,0,0,.06);
+  border-right:1px dashed rgba(0,0,0,.06);
+  min-height:44px;
+  background: rgba(255,255,255,0.3);
 }
 .plan-grid .phdr{ font-weight:600; }
 .plan-grid textarea{
@@ -51,11 +49,17 @@ h2{ margin:0 0 10px; font-size: clamp(18px,3.2vw,22px); }
 .row input[type="text"]{ flex:1 1 280px; }
 .goals{ list-style:none; padding:0; margin:10px 0 0; display:grid; gap:8px; }
 .goals li{
-  background:#fff; border:1px dashed rgba(0,0,0,.15);
-  border-radius:12px; padding:10px 12px; display:flex; gap:10px; align-items:center;
+  background: var(--surface);
+  border:1px dashed rgba(27,31,51,0.12);
+  border-radius:12px;
+  padding:10px 12px;
+  display:flex;
+  gap:10px;
+  align-items:center;
+  box-shadow: 0 16px 32px -28px var(--shadow-strong);
 }
 .goal-pill{ font-size: 20px; width:28px; text-align:center; }
-.goal-date{ opacity:.7; min-width: 105px; }
+.goal-date{ color: var(--ink-faint); min-width: 105px; }
 
 #anchorText{
   width:100%; padding:10px 12px; border:1px solid rgba(0,0,0,.12); border-radius:12px;

--- a/jonah-swirl-school/css/swirlfeed.css
+++ b/jonah-swirl-school/css/swirlfeed.css
@@ -1,52 +1,66 @@
-body { margin:0; background: var(--bg); color: var(--ink); }
+body { margin:0; color: var(--ink); }
 
 .wrap{
-  max-width: 820px;
+  max-width: 880px;
   margin: 0 auto;
-  padding: clamp(14px, 3vw, 24px);
 }
 
 .head{
-  display:flex; align-items:center; gap:12px; flex-wrap:wrap;
-  margin-bottom: 12px;
+  display:flex;
+  align-items:center;
+  gap: clamp(10px, 2.6vw, 18px);
+  flex-wrap:wrap;
 }
-.head h1{ margin:0; font-size: clamp(20px, 3.6vw, 28px); }
+.head h1{ margin:0; font-size: clamp(22px, 4vw, 30px); }
 
 .filters{
-  display:flex; align-items:center; justify-content:space-between;
-  gap:12px; flex-wrap:wrap; margin-bottom: 10px;
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  flex-wrap:wrap;
+  margin-bottom: clamp(12px, 2.8vw, 22px);
 }
 
 .chips{ display:flex; gap:6px; flex-wrap:wrap; }
 .chip{
-  padding:.5rem .8rem; border-radius: 999px; border:2px solid var(--accent1);
-  background:#fff; cursor:pointer;
+  padding:.5rem .85rem;
+  border-radius: 999px;
+  border:2px solid rgba(143,213,196,0.55);
+  background:rgba(255,255,255,0.85);
+  cursor:pointer;
+  transition: transform .2s ease, box-shadow .2s ease;
 }
 .chip.is-active{
   background: var(--accent1);
   color: #003d2f; /* darker text against mint */
   border-color: var(--accent1);
+  box-shadow: 0 14px 26px -18px rgba(143,213,196,0.9);
 }
+.chip:hover{ transform: translateY(-1px); box-shadow: 0 10px 22px -16px rgba(143,213,196,0.6); }
 
 .search input{
   padding:.6rem .9rem;
   border-radius: 12px;
-  border:2px solid rgba(0,0,0,.06);
+  border:1.5px solid rgba(0,0,0,.08);
   background:#fff;
+  transition: border-color .2s ease, box-shadow .2s ease;
 }
+.search input:focus{ border-color: rgba(143,213,196,0.8); box-shadow: 0 0 0 3px rgba(143,213,196,0.2); }
 
 .feed .day-group{
-  margin: 12px 0;
-  background: rgba(255,255,255,.9);
-  border: 2px solid var(--accent1);
+  margin: clamp(18px, 3vw, 26px) 0;
+  background: var(--surface-strong);
+  border: 1.5px solid var(--border-soft);
   border-radius: var(--radius);
-  box-shadow: 0 10px 24px var(--shadow);
+  box-shadow: 0 22px 55px -32px var(--shadow-strong);
   overflow: hidden;
+  backdrop-filter: blur(8px);
 }
 
 .day-head{
   margin:0; padding:10px 12px;
-  background: rgba(143,213,196,.15); /* mint tint */
+  background: rgba(143,213,196,.18); /* mint tint */
   border-bottom: 1px dashed rgba(0,0,0,.1);
   font-weight: 700;
 }

--- a/jonah-swirl-school/css/weekly.css
+++ b/jonah-swirl-school/css/weekly.css
@@ -1,28 +1,20 @@
-body { margin:0; background: var(--bg); color: var(--ink); }
+body { margin:0; color: var(--ink); }
 
 .wrap{
-  max-width: 920px;
+  max-width: 940px;
   margin: 0 auto;
-  padding: clamp(14px, 3vw, 24px);
 }
 
 .head{
-  display:flex; align-items:center; gap:12px; flex-wrap: wrap;
-  margin-bottom: 12px;
+  display:flex;
+  align-items:center;
+  gap: clamp(10px, 2.6vw, 18px);
+  flex-wrap: wrap;
 }
-.head h1{ margin:0; font-size: clamp(20px, 3.6vw, 28px); }
+.head h1{ margin:0; font-size: clamp(22px, 4.2vw, 32px); }
 .head-actions{ margin-left:auto; display:flex; gap:8px; flex-wrap:wrap; }
 
-.card{
-  background: rgba(255,255,255,.9);
-  border: 2px solid var(--accent1);
-  border-radius: var(--radius);
-  box-shadow: 0 10px 24px var(--shadow);
-  padding: 14px;
-  margin: 12px 0;
-}
-
-.hint{ opacity:.7; font-size:.92rem; margin:.25rem 0 0 0; }
+.hint{ color: var(--ink-faint); font-size:.92rem; margin:.25rem 0 0 0; }
 
 .bars{
   display:grid;
@@ -32,10 +24,24 @@ body { margin:0; background: var(--bg); color: var(--ink); }
 .bar{
   display:grid;
   grid-template-columns: 120px 1fr auto;
-  gap:10px; align-items:center;
+  gap:10px;
+  align-items:center;
+  padding:12px;
+  border-radius: 14px;
+  background: rgba(255,255,255,0.6);
+  border: 1px solid rgba(27,31,51,0.05);
 }
 .bar .label{ opacity:.9; }
-.bar .track{ background: rgba(0,0,0,.06); border-radius: 999px; height: 14px; overflow:hidden; }
-.bar .fill{ height:100%; background: var(--accent1); }
+.bar .track{
+  background: rgba(0,0,0,.06);
+  border-radius: 999px;
+  height: 14px;
+  overflow:hidden;
+  position: relative;
+}
+.bar .fill{
+  height:100%;
+  background: linear-gradient(90deg, rgba(143,213,196,0.65), rgba(255,157,216,0.35));
+}
 
 .export-actions{ display:flex; gap:10px; flex-wrap:wrap; }

--- a/jonah-swirl-school/day.html
+++ b/jonah-swirl-school/day.html
@@ -12,11 +12,12 @@
   <!-- DAY VIEW / ENTRY -->
   <!-- QUOTE ROTATOR / VERSE PREVIEW (future) -->
 
-  <main class="day-wrap">
-    <header class="day-head">
+  <main class="day-wrap page-shell">
+    <header class="day-head page-head">
       <a class="btn btn-ghost" href="./index.html">← Home</a>
       <h1>Drop a Crumb</h1>
     </header>
+    <p class="page-intro">Use this space to jot today's moments, tag every pillar they touched, and watch the story thread itself below.</p>
 
     <section id="schedule" class="card">
       <h2>Today's Schedule</h2>

--- a/jonah-swirl-school/evidence.html
+++ b/jonah-swirl-school/evidence.html
@@ -9,13 +9,14 @@
   <link rel="stylesheet" href="./css/blooms.css?v=jonah-1">
 </head>
 <body>
-  <main class="wrap">
-    <header class="head no-print">
+  <main class="wrap page-shell">
+    <header class="head page-head no-print">
       <a class="btn btn-ghost" href="./index.html">← Home</a>
       <div class="spacer"></div>
       <button id="btnPrint" class="btn" type="button">🖨 Print</button>
       <button id="btnJson"  class="btn" type="button">Download JSON</button>
     </header>
+    <p class="page-intro">The Evidence Pack translates the week into gentle documentation you can print or download whenever someone asks for proof of learning.</p>
 
     <section class="card">
       <h1>Evidence Pack</h1>

--- a/jonah-swirl-school/grandma-plan.html
+++ b/jonah-swirl-school/grandma-plan.html
@@ -8,9 +8,9 @@
   <link rel="stylesheet" href="./css/grandma-plan.css?v=jonah-1">
 </head>
 <body>
-  <main class="wrap">
+  <main class="wrap page-shell">
     <!-- HEADER (hidden in print) -->
-    <header class="head no-print">
+    <header class="head page-head no-print">
       <a class="btn btn-ghost" href="./index.html">← Home</a>
       <a class="btn btn-ghost" href="./grandma.html">🗓 Last Week</a>
       <div class="spacer"></div>
@@ -18,6 +18,7 @@
       <button id="btnExportPlan" class="btn" type="button">Export Plan (JSON)</button>
       <button id="btnPrint" class="btn" type="button">🖨 Print</button>
     </header>
+    <p class="page-intro">Build next week's light plan here by sketching one-line rhythms, adding appointments, and setting a gentle anchor for the household.</p>
 
     <!-- TITLE + DATE PICKERS -->
     <section class="card title-card">

--- a/jonah-swirl-school/grandma.html
+++ b/jonah-swirl-school/grandma.html
@@ -9,8 +9,8 @@
   <link rel="stylesheet" href="./css/blooms.css?v=jonah-1">
 </head>
 <body>
-  <main class="wrap">
-    <header class="head no-print">
+  <main class="wrap page-shell">
+    <header class="head page-head no-print">
       <a class="btn btn-ghost" href="./index.html">← Home</a>
       <div class="spacer"></div>
       <a class="btn btn-ghost" href="./day.html">✍️ Day</a>
@@ -19,6 +19,7 @@
       <a class="btn btn-ghost" href="./grandma-plan.html">🗒️ Plan Next</a>
       <button id="seedToPlan" class="btn" type="button">→ Seed Next Week Plan</button>
     </header>
+    <p class="page-intro">Grandma Recap bridges soft memories into planning mode by summarizing the week and seeding gentle nudges for what comes next.</p>
 
     <section class="week-range card" aria-live="polite">
       <h2 id="weekLabel">Week</h2>

--- a/jonah-swirl-school/index.html
+++ b/jonah-swirl-school/index.html
@@ -28,6 +28,7 @@
     <div class="site-banner">
       <h1>Life is Learning</h1>
       <p>Jonahs Swirl School</p>
+      <p class="page-intro">Start at the swirl hub to feel today's glow and choose the door you need; tap the bright center when you're ready to drop a crumb for the day.</p>
     </div>
     <div class="swirl" aria-hidden="true">
       <svg viewBox="0 0 200 200" class="swirl-svg">

--- a/jonah-swirl-school/swirlfeed.html
+++ b/jonah-swirl-school/swirlfeed.html
@@ -8,11 +8,12 @@
   <link rel="stylesheet" href="./css/swirlfeed.css?v=jonah-1">
 </head>
 <body>
-  <main class="wrap">
-    <header class="head">
+  <main class="wrap page-shell">
+    <header class="head page-head">
       <a class="btn btn-ghost" href="./index.html">← Home</a>
       <h1>Swirlfeed</h1>
     </header>
+    <p class="page-intro">Scroll this cozy feed to replay every crumb, filter by pillar, and open the ones you want to linger with a little longer.</p>
 
     <!-- FILTER BAR -->
     <section class="filters" aria-label="Filter crumbs">

--- a/jonah-swirl-school/weekly.html
+++ b/jonah-swirl-school/weekly.html
@@ -10,8 +10,8 @@
   <link rel="stylesheet" href="./css/settings.css?v=jonah-1">
 </head>
 <body>
-  <main class="wrap">
-    <header class="head">
+  <main class="wrap page-shell">
+    <header class="head page-head">
       <a class="btn btn-ghost" href="./index.html">← Home</a>
       <h1>Weekly Glow</h1>
       <div class="head-actions">
@@ -23,6 +23,7 @@
         <button id="printWeek" class="btn" type="button">🖨 Print</button>
       </div>
     </header>
+    <p class="page-intro">This view gathers the week at a glance so you can watch patterns emerge, nudge quieter pillars, and export whatever record you need.</p>
 
     <section class="week-range card" aria-live="polite">
       <h2 id="weekLabel">Week</h2>


### PR DESCRIPTION
## Summary
- add palette tokens, gradient backgrounds, and shared shell/card/button styles to make Swirl School views feel cohesive
- refresh day, feed, weekly, evidence, and planning layouts to use the new aesthetic and clearer spacing cues
- add gentle grey page-intro copy on each hub view so families understand what to do on every screen

## Testing
- not run (static HTML/CSS changes only)

------
https://chatgpt.com/codex/tasks/task_e_68c96650ebbc832e8bf61fa77c5b7e4e