### PR TITLE
Ensure Swirl School buttons save and refresh data

### DIFF
--- a/jonah-swirl-school/day.html
+++ b/jonah-swirl-school/day.html
@@ -163,7 +163,7 @@
 
     function renderNarrative(){
       const crumbs = todayCrumbs();
-      narrativeText.textContent = crumbs.map(c=> c.text).join(' ');
+      narrativeText.textContent = crumbs.slice().reverse().map(c=> c.text).join(' ');
     }
 
     function renderSchedule(){

--- a/jonah-swirl-school/grandma.html
+++ b/jonah-swirl-school/grandma.html
@@ -132,6 +132,11 @@
       return d.toISOString().slice(0,7);
     }
 
+    window.addEventListener('swirl:changed', (evt)=>{
+      const type = evt.detail?.type || '';
+      if(type.startsWith('crumb_')) render();
+    });
+
     render();
   </script>
 </body>

--- a/jonah-swirl-school/weekly.html
+++ b/jonah-swirl-school/weekly.html
@@ -100,6 +100,12 @@
 
     printBtn.onclick = ()=> window.print();
 
+    // Update when crumbs change elsewhere
+    window.addEventListener('swirl:changed', (evt)=>{
+      const type = evt.detail?.type || '';
+      if(type.startsWith('crumb_')) render();
+    });
+
     // initial
     render();
   </script>


### PR DESCRIPTION
## Summary
- wire the hub quick-entry box to `saveCrumb`, remember the last pillar, and give inline feedback when a crumb is captured
- normalize stored crumbs with guaranteed ids/timestamps and keep the list sorted so today/week views pull newest-first data
- refresh the feed, weekly, and grandma recaps when crumbs change and adjust the day narrative to read chronologically

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c96d025700832e846f7a6d2501d384