### PR TITLE
Revamp Jonah Swirlfeed with IG-style experience

### DIFF
--- a/jonah-swirl-school/css/swirlfeed.css
+++ b/jonah-swirl-school/css/swirlfeed.css
@@ -1,89 +1,295 @@
-body { margin:0; color: var(--ink); }
+body{ margin:0; color: var(--ink); background: var(--bg); }
 
-.wrap{
-  max-width: 880px;
-  margin: 0 auto;
+.stories{
+  margin: clamp(6px, 2.2vw, 18px) 0 clamp(16px, 4vw, 28px);
+  padding: 0 clamp(6px, 2.5vw, 12px);
 }
 
-.head{
-  display:flex;
-  align-items:center;
-  gap: clamp(10px, 2.6vw, 18px);
-  flex-wrap:wrap;
+.story-track{
+  display:flex;
+  gap: clamp(12px, 3vw, 22px);
+  overflow-x:auto;
+  padding-bottom: 6px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(27,31,51,0.28) transparent;
 }
-.head h1{ margin:0; font-size: clamp(22px, 4vw, 30px); }
+.story-track::-webkit-scrollbar{ height:6px; }
+.story-track::-webkit-scrollbar-thumb{
+  background: rgba(27,31,51,0.18);
+  border-radius: 999px;
+}
+
+.story-chip{
+  background: transparent;
+  border:0;
+  color: inherit;
+  cursor: pointer;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:8px;
+  padding: 4px;
+  min-width: clamp(68px, 16vw, 96px);
+}
+.story-chip:focus-visible{
+  outline: 3px solid var(--accent1);
+  outline-offset: 4px;
+  border-radius: 16px;
+}
+.story-avatar{
+  position:relative;
+  display:grid;
+  place-items:center;
+  width: clamp(60px, 18vw, 84px);
+  height: clamp(60px, 18vw, 84px);
+  border-radius: 50%;
+  background: var(--surface-strong);
+  box-shadow: 0 0 0 3px var(--paper), 0 16px 34px -24px var(--shadow-strong);
+  transition: transform .2s ease, box-shadow .2s ease;
+}
+.story-avatar::after{
+  content:"";
+  position:absolute;
+  inset:-3px;
+  border-radius:inherit;
+  box-shadow: 0 0 0 0 var(--ring, rgba(27,31,51,0.22));
+  transition: box-shadow .2s ease;
+}
+.story-emoji{
+  font-size: clamp(1.6rem, 4.4vw, 2.1rem);
+  line-height:1;
+}
+.story-label{
+  font-size: .8rem;
+  opacity: .78;
+  text-transform: capitalize;
+}
+.story-chip:hover .story-avatar,
+.story-chip.is-active .story-avatar{
+  transform: translateY(-2px);
+}
+.story-chip:hover .story-avatar::after,
+.story-chip.is-active .story-avatar::after{
+  box-shadow: 0 0 0 4px var(--ring, rgba(143,213,196,0.65));
+}
 
 .filters{
-  display:flex;
-  align-items:center;
-  justify-content:space-between;
-  gap:12px;
-  flex-wrap:wrap;
-  margin-bottom: clamp(12px, 2.8vw, 22px);
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap: clamp(12px, 3vw, 20px);
+  flex-wrap:wrap;
+  margin-bottom: clamp(18px, 4vw, 32px);
 }
 
 .chips{ display:flex; gap:6px; flex-wrap:wrap; }
 .chip{
-  padding:.5rem .85rem;
-  border-radius: 999px;
-  border:2px solid rgba(143,213,196,0.55);
-  background:rgba(255,255,255,0.85);
-  cursor:pointer;
-  transition: transform .2s ease, box-shadow .2s ease;
+  padding:.55rem .95rem;
+  border-radius: 999px;
+  border:2px solid rgba(143,213,196,0.4);
+  background: rgba(255,255,255,0.85);
+  cursor:pointer;
+  transition: transform .2s ease, box-shadow .2s ease;
 }
 .chip.is-active{
-  background: var(--accent1);
-  color: #003d2f; /* darker text against mint */
-  border-color: var(--accent1);
-  box-shadow: 0 14px 26px -18px rgba(143,213,196,0.9);
+  background: var(--accent1);
+  color: #0f2f27;
+  border-color: var(--accent1);
+  box-shadow: 0 16px 30px -20px rgba(143,213,196,0.9);
 }
-.chip:hover{ transform: translateY(-1px); box-shadow: 0 10px 22px -16px rgba(143,213,196,0.6); }
+.chip:hover{ transform: translateY(-1px); box-shadow: 0 12px 24px -18px rgba(143,213,196,0.6); }
 
 .search input{
-  padding:.6rem .9rem;
-  border-radius: 12px;
-  border:1.5px solid rgba(0,0,0,.08);
-  background:#fff;
-  transition: border-color .2s ease, box-shadow .2s ease;
+  padding:.65rem 1rem;
+  border-radius: 14px;
+  border:1.5px solid rgba(27,31,51,0.12);
+  background:#fff;
+  transition: border-color .2s ease, box-shadow .2s ease;
 }
-.search input:focus{ border-color: rgba(143,213,196,0.8); box-shadow: 0 0 0 3px rgba(143,213,196,0.2); }
-
-.feed .day-group{
-  margin: clamp(18px, 3vw, 26px) 0;
-  background: var(--surface-strong);
-  border: 1.5px solid var(--border-soft);
-  border-radius: var(--radius);
-  box-shadow: 0 22px 55px -32px var(--shadow-strong);
-  overflow: hidden;
-  backdrop-filter: blur(8px);
+.search input:focus{
+  border-color: rgba(143,213,196,0.8);
+  box-shadow: 0 0 0 3px rgba(143,213,196,0.22);
+  outline: none;
 }
 
-.day-head{
-  margin:0; padding:10px 12px;
-  background: rgba(143,213,196,.18); /* mint tint */
-  border-bottom: 1px dashed rgba(0,0,0,.1);
-  font-weight: 700;
+.feed #feedRoot{
+  display:grid;
+  gap: clamp(18px, 3vw, 28px);
 }
 
-.item{
-  display:grid;
-  grid-template-columns: 1fr auto;
-  gap: 10px; align-items:flex-start;
-  padding:10px 12px;
-  border-bottom:1px dashed rgba(0,0,0,.08);
+.feed-post{
+  background: var(--surface-strong);
+  border-radius: var(--radius);
+  border: 1.5px solid var(--border-soft);
+  box-shadow: 0 26px 60px -36px var(--shadow-strong);
+  overflow:hidden;
+  backdrop-filter: blur(8px);
 }
-.item:last-child{ border-bottom:0; }
 
-.item .txt{ white-space: pre-wrap; }
-.item .pillar-chips{ grid-column: 1 / -1; margin-top: 4px; }
-
-.item .go{
-  display:inline-flex; align-items:center; gap:6px;
-  padding:.45rem .7rem; border-radius: 10px; border:2px solid var(--accent1);
-  background: rgba(255,255,255,.8); cursor:pointer;
+.post-head{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap: clamp(12px, 3vw, 20px);
+  padding: clamp(16px, 3vw, 22px);
 }
-.item .go:hover{ box-shadow: 0 0 0 3px rgba(143,213,196,.25); }
+.post-ident{
+  display:flex;
+  align-items:center;
+  gap: 12px;
+}
+.post-avatar{
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  display:grid;
+  place-items:center;
+  font-size: 1.35rem;
+  background: var(--surface);
+  box-shadow: inset 0 0 0 2px rgba(27,31,51,0.08);
+}
+.post-meta{ display:flex; flex-direction:column; gap:4px; }
+.post-day{ font-weight: 600; font-size: 1rem; }
+.post-time{ font-size: .85rem; color: var(--ink-faint); }
 
-.cover{ cursor:pointer; }
-.cover img{ display:block; width:100%; height:auto; }
-.day-details.hidden{ display:none; }
+.post-body{
+  padding: 0 clamp(16px, 3vw, 22px) clamp(14px, 3vw, 24px);
+}
+.post-caption{
+  margin: 0;
+  font-size: clamp(1rem, 2.8vw, 1.12rem);
+  font-weight: 600;
+  white-space: pre-wrap;
+}
+.post-summary{
+  margin: clamp(8px, 2vw, 12px) 0 0;
+  color: var(--ink-mist);
+  white-space: pre-wrap;
+}
+.post-more{
+  margin: clamp(8px, 2vw, 14px) 0 0;
+  font-size: .9rem;
+  color: var(--ink-faint);
+}
+.post-pillars{
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px;
+  margin-top: clamp(10px, 2.2vw, 16px);
+}
+
+.post-media{
+  margin: 0;
+  position: relative;
+  background: rgba(27,31,51,0.04);
+}
+.post-media img{
+  display:block;
+  width:100%;
+  max-height: 420px;
+  object-fit: cover;
+}
+
+.post-actions{
+  display:flex;
+  align-items:center;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding: 12px clamp(16px, 3vw, 22px);
+  border-top: 1px solid var(--border-soft);
+}
+.post-actions button{
+  background: rgba(255,255,255,0.9);
+  border:1.5px solid rgba(27,31,51,0.08);
+  color: inherit;
+  font-size: .95rem;
+  border-radius: 14px;
+  padding: .45rem .85rem;
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  cursor:pointer;
+  transition: transform .2s ease, box-shadow .2s ease;
+}
+.post-actions button:hover{
+  transform: translateY(-1px);
+  box-shadow: 0 14px 26px -20px rgba(27,31,51,0.3);
+}
+.post-actions button:focus-visible{
+  outline: 3px solid var(--accent1);
+  outline-offset: 3px;
+}
+.action-like[data-liked="true"]{
+  background: var(--grad-like);
+  border-color: rgba(255,157,216,0.55);
+  color: #5b1030;
+}
+.action-feedback{
+  margin-left:auto;
+  font-size: .85rem;
+  color: var(--ink-faint);
+  min-width: 120px;
+  text-align:right;
+}
+
+.post-thread{
+  padding: 0 clamp(16px, 3vw, 22px) clamp(16px, 3vw, 26px);
+  border-top: 1px solid var(--border-soft);
+  background: var(--surface);
+}
+.post-thread[hidden]{ display:none; }
+
+.thread-list{
+  list-style:none;
+  margin: 0;
+  padding: 0;
+  display:grid;
+  gap: clamp(10px, 2vw, 16px);
+}
+.thread-item{
+  padding: clamp(10px, 2.4vw, 16px);
+  border-radius: 16px;
+  border: 1px solid var(--border-soft);
+  background: rgba(255,255,255,0.7);
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.5);
+}
+.thread-top{
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-start;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+.thread-time{ font-size: .8rem; color: var(--ink-faint); }
+.thread-text{ white-space: pre-wrap; }
+.thread-media img{
+  display:block;
+  width:100%;
+  margin-top: 8px;
+  border-radius: 12px;
+}
+.thread-pillars{ margin-top: 8px; }
+
+.thread-open{
+  margin-top: clamp(12px, 2.4vw, 18px);
+  background: none;
+  border:0;
+  color: var(--accent1);
+  font-weight: 600;
+  cursor:pointer;
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  padding: .4rem 0;
+}
+.thread-open:focus-visible{
+  outline: 2px solid var(--accent1);
+  outline-offset: 3px;
+  border-radius: 8px;
+}
+
+@media (max-width: 640px){
+  .post-actions{ align-items: stretch; }
+  .post-actions button{ flex:1 1 calc(33% - 12px); justify-content:center; }
+  .action-feedback{ flex-basis:100%; text-align:left; margin-left:0; margin-top:4px; }
+}

--- a/jonah-swirl-school/js/storage.js
+++ b/jonah-swirl-school/js/storage.js
@@ -308,8 +308,33 @@ export function pinExists(){ return Storage.pinExists(); }
 export function verifyPin(input){ return Storage.verifyPin(input); }
 export function setPin(newPin, currentPin){ return Storage.setPin(newPin, currentPin); }
 
+const REACT_KEY = 'swirl_reacts_like_jonah';
+function _likes(){
+  try{
+    return new Set(JSON.parse(localStorage.getItem(REACT_KEY) || '[]'));
+  }catch{
+    return new Set();
+  }
+}
+function _saveLikes(set){
+  localStorage.setItem(REACT_KEY, JSON.stringify([...set]));
+}
+export function isLiked(crumbId){
+  return _likes().has(crumbId);
+}
+export function toggleLike(crumbId){
+  const s = _likes();
+  if(s.has(crumbId)) s.delete(crumbId);
+  else s.add(crumbId);
+  _saveLikes(s);
+  try{
+    window.dispatchEvent(new CustomEvent('swirl:changed', { detail:{ type:'like_toggle', crumbId } }));
+  }catch{}
+  return s.has(crumbId);
+}
+
 // Extra getters useful for full snapshot export/import later:
-export function _all(){ 
+export function _all(){
   return {
     crumbs: Storage.getCrumbs(),
     comments: Storage.getComments(),

--- a/jonah-swirl-school/js/swirlfeed.js
+++ b/jonah-swirl-school/js/swirlfeed.js
@@ -1,191 +1,532 @@
-// Neutral Swirlfeed (filters + search + date groups)
-// Uses listCrumbs() from storage.js
-
-import { listCrumbs } from './storage.js';
+import { listCrumbs, toggleLike, isLiked } from './storage.js';
 import { seasonClass } from './season.js';
 
 const feedRoot = document.getElementById('feedRoot');
-const chipRow  = document.querySelector('.chips');
-const qInput   = document.getElementById('q');
+const chipRow = document.querySelector('.chips');
+const storyTrack = document.getElementById('storyTrack');
+const qInput = document.getElementById('q');
 
-if(!feedRoot) {
+if(!feedRoot){
   console.warn('Swirlfeed: root element missing');
 }
 
 let currentPill = 'all';
 let q = '';
 
-const PILL_LABEL = {
-  divine: 'Spiritual Routine',
-  family: 'Home',
-  self:   'Self',
-  rrr:    'Skills',
-  work:   'Work'
+const PILL_META = {
+  divine: { label: 'Spiritual Routine', emoji: '👑', ring: 'var(--pillar-spiritual)' },
+  family: { label: 'Home', emoji: '🏠', ring: 'var(--pillar-family)' },
+  self:   { label: 'Self', emoji: '🌱', ring: 'var(--pillar-self)' },
+  rrr:    { label: 'Skills', emoji: '📚', ring: 'var(--pillar-rrr)' },
+  work:   { label: 'Work', emoji: '💵', ring: 'var(--pillar-work)' }
 };
+const ORDERED_PILLARS = ['divine','family','self','rrr','work'];
+const STORY_ORDER = ['all', ...ORDERED_PILLARS];
 
-// preselect pillar from URL hash if provided
 const hashPill = (location.hash || '').replace('#','').trim();
-if(hashPill && PILL_LABEL[hashPill] && chipRow){
+if(hashPill && (hashPill === 'all' || ORDERED_PILLARS.includes(hashPill))){
   currentPill = hashPill;
-  chipRow.querySelectorAll('.chip').forEach(c => {
-    const active = c.dataset.pill === currentPill;
-    c.classList.toggle('is-active', active);
-    c.setAttribute('aria-selected', active ? 'true' : 'false');
-  });
 }
 
-function dateOnly(iso){ return (iso||'').slice(0,10); }
-function emojiFor(p){ return ({divine:'👑', family:'🏠', self:'🌱', rrr:'📚', work:'💵'})[p] || '•'; }
 function ensurePillars(crumb){
-  if(Array.isArray(crumb.pillars) && crumb.pillars.length) return crumb.pillars;
-  return crumb.pillar ? [crumb.pillar] : [];
+  if(Array.isArray(crumb?.pillars) && crumb.pillars.length) return crumb.pillars;
+  if(crumb?.pillar) return [crumb.pillar];
+  return [];
 }
 
-function normalize(s){ return (s||'').toLowerCase(); }
+function emojiFor(pillar){
+  return PILL_META[pillar]?.emoji || '🌀';
+}
 
-/** Filter crumbs by pillar + search query */
+function normalize(str){
+  return (str || '').toLowerCase().trim();
+}
+
 function filtered(){
-  const all = listCrumbs(); // newest first (we sorted in storage API)
-  const qn = normalize(q);
-  return all.filter(c=>{
-    if(currentPill !== 'all' && !ensurePillars(c).includes(currentPill)) return false;
-    if(!qn) return true;
-    const hay = [
-      c.text,
-      ...(Array.isArray(c.tags) ? c.tags : []),
-      ...(Array.isArray(c.skills) ? c.skills : []),
-      ...(Array.isArray(c.parts) ? c.parts : []),
-      ...ensurePillars(c).map(p=> PILL_LABEL[p] || p)
+  const all = listCrumbs();
+  const qn = normalize(q);
+  return all.filter(crumb => {
+    if(currentPill !== 'all' && !ensurePillars(crumb).includes(currentPill)) return false;
+    if(!qn) return true;
+    const haystack = [
+      crumb.text,
+      ...(Array.isArray(crumb.tags) ? crumb.tags : []),
+      ...(Array.isArray(crumb.skills) ? crumb.skills : []),
+      ...(Array.isArray(crumb.parts) ? crumb.parts : []),
+      ...ensurePillars(crumb).map(p => PILL_META[p]?.label || p)
     ].join(' ').toLowerCase();
-    return hay.includes(qn);
-  });
-}
-
-/** Group by YYYY-MM-DD */
-function groupByDay(rows){
-  const map = new Map();
-  for(const c of rows){
-    const d = dateOnly(c.tsISO);
-    if(!map.has(d)) map.set(d, []);
-    map.get(d).push(c);
-  }
-  return [...map.entries()].sort((a,b)=> b[0].localeCompare(a[0])); // newest day first
-}
-
-function escapeHtml(s){ return (s||'').replace(/[&<>"']/g, m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;', "'":'&#39;' }[m])); }
-
-function makeItem(c){
-  const div = document.createElement('div');
-  div.className = 'item crumb-age ' + seasonClass(c.tsISO);
-  const pillars = ensurePillars(c);
-  const primary = pillars[0] || c.pillar;
-  const chips = pillars.length
-    ? `<div class="pillar-chips">${pillars.map(p=>`<span class="pillar-chip" data-pillar="${p}">${emojiFor(p)} ${PILL_LABEL[p]||p}</span>`).join('')}</div>`
-    : '';
-  const aria = pillars.length ? pillars.map(p=> PILL_LABEL[p] || p).join(', ') : (PILL_LABEL[primary] || primary || 'pillar');
-  div.innerHTML = `
-    <div class="txt">${emojiFor(primary)} ${escapeHtml(c.text)}</div>
-    ${chips}
-    <button class="go" type="button" aria-label="Add another ${aria} crumb">Go →</button>
-  `;
-  const go = div.querySelector('.go');
-  go.addEventListener('click', ()=>{
-    location.href = primary ? `./day.html#${primary}` : './day.html';
+    return haystack.includes(qn);
   });
-  return div;
+}
+
+function groupByDay(rows){
+  const map = new Map();
+  for(const crumb of rows){
+    const day = (crumb.tsISO || '').slice(0,10);
+    if(!map.has(day)) map.set(day, []);
+    map.get(day).push(crumb);
+  }
+  return [...map.entries()].sort((a,b) => b[0].localeCompare(a[0]));
+}
+
+function parseDay(day){
+  const [y,m,d] = (day || '').split('-').map(Number);
+  if([y,m,d].some(n => Number.isNaN(n))) return null;
+  return new Date(y, m - 1, d);
+}
+
+function formatDayLabel(day){
+  const dt = parseDay(day);
+  if(!dt) return day;
+  return new Intl.DateTimeFormat(undefined, { weekday:'long', month:'short', day:'numeric' }).format(dt);
+}
+
+function relativeDayLabel(day){
+  const dt = parseDay(day);
+  if(!dt) return '';
+  const today = new Date();
+  const startToday = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const startTarget = new Date(dt.getFullYear(), dt.getMonth(), dt.getDate());
+  const diff = Math.round((startToday - startTarget) / 86400000);
+  if(diff === 0) return 'Today';
+  if(diff === 1) return 'Yesterday';
+  if(diff > 1 && diff < 7) return `${diff} days ago`;
+  return '';
+}
+
+function formatTimeLabel(ts){
+  if(!ts) return '';
+  const dt = new Date(ts);
+  if(Number.isNaN(dt.getTime())) return '';
+  return new Intl.DateTimeFormat(undefined, { hour:'numeric', minute:'2-digit' }).format(dt);
+}
+
+function crumbCountLabel(n){
+  if(!n) return '';
+  return `${n} ${n === 1 ? 'crumb' : 'crumbs'}`;
+}
+
+function heroMedia(crumb){
+  if(!crumb || !Array.isArray(crumb.media)) return null;
+  return crumb.media.find(m => {
+    if(!m) return false;
+    if(m.kind === 'image') return true;
+    if(m.kind === 'photo') return true;
+    if(typeof m.type === 'string' && m.type.startsWith('image/')) return true;
+    return false;
+  }) || null;
+}
+
+function uniquePillars(items){
+  const set = new Set();
+  for(const crumb of items){
+    ensurePillars(crumb).forEach(p => set.add(p));
+  }
+  return STORY_ORDER.filter(p => p !== 'all' && set.has(p));
+}
+
+function summaryText(items){
+  const rest = items.slice(1).map(c => c.text || '').filter(Boolean).join(' ');
+  if(!rest) return '';
+  const trimmed = rest.trim();
+  if(trimmed.length <= 320) return trimmed;
+  return trimmed.slice(0, 320).trimEnd() + '…';
+}
+
+function buildPillarChips(pillars, extraClass = ''){
+  if(!pillars.length) return null;
+  const wrap = document.createElement('div');
+  wrap.className = extraClass ? `pillar-chips ${extraClass}` : 'pillar-chips';
+  pillars.forEach(p => {
+    const span = document.createElement('span');
+    span.className = 'pillar-chip';
+    span.dataset.pillar = p;
+    span.textContent = `${emojiFor(p)} ${PILL_META[p]?.label || p}`;
+    wrap.appendChild(span);
+  });
+  return wrap;
+}
+
+function buildThread(day, items){
+  const section = document.createElement('section');
+  section.className = 'post-thread';
+  section.hidden = true;
+  const slug = (day || '').replace(/[^0-9a-z]/gi, '');
+  section.id = slug ? `thread-${slug}` : `thread-${Math.random().toString(36).slice(2,8)}`;
+
+  const list = document.createElement('ul');
+  list.className = 'thread-list';
+  items.forEach(crumb => {
+    const li = document.createElement('li');
+    li.className = 'thread-item crumb-age ' + seasonClass(crumb.tsISO);
+
+    const top = document.createElement('div');
+    top.className = 'thread-top';
+    const time = document.createElement('span');
+    time.className = 'thread-time';
+    time.textContent = formatTimeLabel(crumb.tsISO);
+    top.appendChild(time);
+    li.appendChild(top);
+
+    const pillars = ensurePillars(crumb);
+    const text = document.createElement('div');
+    text.className = 'thread-text';
+    const emoji = pillars.length ? emojiFor(pillars[0]) : '•';
+    text.textContent = `${emoji} ${crumb.text || ''}`.trim();
+    li.appendChild(text);
+
+    const chips = buildPillarChips(pillars, 'thread-pillars');
+    if(chips) li.appendChild(chips);
+
+    const media = heroMedia(crumb);
+    if(media){
+      const mediaWrap = document.createElement('div');
+      mediaWrap.className = 'thread-media';
+      const img = document.createElement('img');
+      img.src = media.dataUrl || media.url || '';
+      img.alt = media.alt || 'Crumb photo';
+      mediaWrap.appendChild(img);
+      li.appendChild(mediaWrap);
+    }
+
+    list.appendChild(li);
+  });
+  section.appendChild(list);
+
+  const openBtn = document.createElement('button');
+  openBtn.className = 'thread-open';
+  openBtn.type = 'button';
+  openBtn.textContent = 'Open day journal';
+  openBtn.dataset.day = day;
+  section.appendChild(openBtn);
+
+  return section;
+}
+
+function smoothScrollIntoView(el){
+  if(!el || typeof el.scrollIntoView !== 'function') return;
+  const prefersReduce = typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  el.scrollIntoView({ block: 'nearest', behavior: prefersReduce ? 'auto' : 'smooth' });
+}
+
+function updateLikeButton(btn, liked){
+  btn.dataset.liked = liked ? 'true' : 'false';
+  btn.setAttribute('aria-pressed', liked ? 'true' : 'false');
+  btn.setAttribute('aria-label', liked ? 'Unlike this crumb' : 'Like this crumb');
+  btn.innerHTML = liked ? '❤️ <span>Liked</span>' : '🤍 <span>Like</span>';
+}
+
+function showFeedback(el, text){
+  if(!el) return;
+  el.textContent = text;
+  if(el._timer) clearTimeout(el._timer);
+  el._timer = setTimeout(() => {
+    el.textContent = '';
+  }, 4000);
+}
+
+async function shareDayLink(day, feedback){
+  try{
+    const url = new URL('./day.html', location.href);
+    url.search = `?d=${day}`;
+    const shareUrl = url.toString();
+    if(navigator.share){
+      await navigator.share({ title: `Jonah · ${day}`, url: shareUrl });
+      showFeedback(feedback, 'Shared');
+      return;
+    }
+    if(navigator.clipboard && navigator.clipboard.writeText){
+      await navigator.clipboard.writeText(shareUrl);
+      showFeedback(feedback, 'Link copied');
+      return;
+    }
+    const a = document.createElement('a');
+    a.href = shareUrl;
+    a.target = '_blank';
+    a.rel = 'noopener';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    showFeedback(feedback, 'Opened day view');
+  }catch(err){
+    console.error('Share failed', err);
+    showFeedback(feedback, 'Link ready in address bar');
+  }
+}
+
+function makePost(day, items){
+  const primary = items[0];
+  const article = document.createElement('article');
+  article.className = 'feed-post crumb-age ' + seasonClass(primary?.tsISO);
+
+  const header = document.createElement('header');
+  header.className = 'post-head';
+  article.appendChild(header);
+
+  const ident = document.createElement('div');
+  ident.className = 'post-ident';
+  header.appendChild(ident);
+
+  const avatar = document.createElement('div');
+  avatar.className = 'post-avatar';
+  avatar.textContent = emojiFor(ensurePillars(primary)[0]) || '🌀';
+  ident.appendChild(avatar);
+
+  const meta = document.createElement('div');
+  meta.className = 'post-meta';
+  ident.appendChild(meta);
+
+  const dayLabel = document.createElement('span');
+  dayLabel.className = 'post-day';
+  dayLabel.textContent = formatDayLabel(day);
+  meta.appendChild(dayLabel);
+
+  const info = document.createElement('span');
+  info.className = 'post-time';
+  const rel = relativeDayLabel(day);
+  const timeLabel = formatTimeLabel(primary?.tsISO);
+  const countLabel = crumbCountLabel(items.length);
+  info.textContent = [rel || timeLabel, countLabel].filter(Boolean).join(' · ');
+  meta.appendChild(info);
+
+  const hero = heroMedia(primary);
+  if(hero){
+    const figure = document.createElement('figure');
+    figure.className = 'post-media';
+    const img = document.createElement('img');
+    img.src = hero.dataUrl || hero.url || '';
+    img.alt = hero.alt || 'Crumb photo';
+    figure.appendChild(img);
+    article.appendChild(figure);
+  }
+
+  const body = document.createElement('div');
+  body.className = 'post-body';
+  article.appendChild(body);
+
+  const caption = document.createElement('p');
+  caption.className = 'post-caption';
+  const mainEmoji = emojiFor(ensurePillars(primary)[0]);
+  caption.textContent = primary ? `${mainEmoji} ${primary.text || ''}`.trim() : 'No crumbs logged yet.';
+  body.appendChild(caption);
+
+  const summary = summaryText(items);
+  if(summary){
+    const summaryEl = document.createElement('p');
+    summaryEl.className = 'post-summary';
+    summaryEl.textContent = summary;
+    body.appendChild(summaryEl);
+  }
+
+  const extraCount = items.length - 1;
+  if(extraCount > 0){
+    const more = document.createElement('p');
+    more.className = 'post-more';
+    more.textContent = `+${extraCount} more ${extraCount === 1 ? 'moment' : 'moments'} in this day`;
+    body.appendChild(more);
+  }
+
+  const dayPillars = uniquePillars(items);
+  const chips = buildPillarChips(dayPillars, 'post-pillars');
+  if(chips) body.appendChild(chips);
+
+  const actions = document.createElement('div');
+  actions.className = 'post-actions';
+  article.appendChild(actions);
+
+  const likeBtn = document.createElement('button');
+  likeBtn.className = 'action-like';
+  likeBtn.type = 'button';
+  likeBtn.setAttribute('aria-pressed', 'false');
+  actions.appendChild(likeBtn);
+
+  const commentBtn = document.createElement('button');
+  commentBtn.className = 'action-comment';
+  commentBtn.type = 'button';
+  commentBtn.innerHTML = '💬 <span>View crumbs</span>';
+  commentBtn.setAttribute('aria-expanded', 'false');
+  actions.appendChild(commentBtn);
+
+  const shareBtn = document.createElement('button');
+  shareBtn.className = 'action-share';
+  shareBtn.type = 'button';
+  shareBtn.innerHTML = '↗︎ <span>Share</span>';
+  shareBtn.setAttribute('aria-label', 'Share day link');
+  actions.appendChild(shareBtn);
+
+  const feedback = document.createElement('div');
+  feedback.className = 'action-feedback';
+  feedback.setAttribute('aria-live', 'polite');
+  actions.appendChild(feedback);
+
+  const thread = buildThread(day, items);
+  article.appendChild(thread);
+
+  commentBtn.setAttribute('aria-controls', thread.id);
+  commentBtn.addEventListener('click', () => {
+    const expanded = commentBtn.getAttribute('aria-expanded') === 'true';
+    const next = !expanded;
+    commentBtn.setAttribute('aria-expanded', next ? 'true' : 'false');
+    commentBtn.querySelector('span').textContent = next ? 'Hide crumbs' : 'View crumbs';
+    thread.hidden = !next;
+    if(next){
+      smoothScrollIntoView(thread);
+    }
+  });
+
+  if(primary){
+    updateLikeButton(likeBtn, isLiked(primary.id));
+    likeBtn.addEventListener('click', () => {
+      const liked = toggleLike(primary.id);
+      updateLikeButton(likeBtn, liked);
+    });
+  }else{
+    likeBtn.disabled = true;
+    updateLikeButton(likeBtn, false);
+  }
+
+  shareBtn.addEventListener('click', () => {
+    shareDayLink(day, feedback);
+  });
+
+  const openBtn = thread.querySelector('.thread-open');
+  openBtn?.addEventListener('click', () => {
+    location.href = `./day.html?d=${day}`;
+  });
+
+  return article;
+}
+
+function updateChipRow(){
+  if(!chipRow) return;
+  chipRow.querySelectorAll('.chip').forEach(btn => {
+    const active = btn.dataset.pill === currentPill;
+    btn.classList.toggle('is-active', active);
+    btn.setAttribute('aria-selected', active ? 'true' : 'false');
+  });
+}
+
+function pillarCounts(){
+  const counts = { divine:0, family:0, self:0, rrr:0, work:0 };
+  for(const crumb of listCrumbs()){
+    ensurePillars(crumb).forEach(p => {
+      if(p in counts) counts[p] += 1;
+    });
+  }
+  return counts;
+}
+
+function storyMeta(id, counts){
+  if(id === 'all'){
+    const total = Object.values(counts).reduce((sum, n) => sum + n, 0);
+    return {
+      emoji: '🌀',
+      ring: 'var(--accent1)',
+      label: 'All pillars',
+      short: 'All',
+      aria: `All pillars — ${total} ${total === 1 ? 'crumb' : 'crumbs'}`
+    };
+  }
+  const meta = PILL_META[id];
+  const count = counts[id] || 0;
+  return {
+    emoji: meta.emoji,
+    ring: meta.ring,
+    label: meta.label,
+    short: meta.label.split(' ')[0],
+    aria: `${meta.label} — ${count} ${count === 1 ? 'crumb' : 'crumbs'}`
+  };
+}
+
+function renderStories(){
+  if(!storyTrack) return;
+  const counts = pillarCounts();
+  storyTrack.innerHTML = STORY_ORDER.map(id => {
+    const meta = storyMeta(id, counts);
+    const active = currentPill === id;
+    return `<button class="story-chip${active ? ' is-active' : ''}" data-pill="${id}" aria-label="${meta.aria}">
+      <span class="story-avatar" style="--ring:${meta.ring};">
+        <span class="story-emoji" aria-hidden="true">${meta.emoji}</span>
+      </span>
+      <span class="story-label">${meta.short}</span>
+    </button>`;
+  }).join('');
 }
 
 function render(){
   if(!feedRoot) return;
+  updateChipRow();
+  renderStories();
+
   const rows = filtered();
   const groups = groupByDay(rows);
 
   feedRoot.innerHTML = '';
   if(!groups.length){
-    const p = document.createElement('p');
-    p.className = 'hint';
-    p.textContent = q || currentPill!=='all'
-      ? 'No crumbs match your filters yet.'
-      : 'No crumbs yet. Drop one from the Home doors or Day page.';
-    feedRoot.appendChild(p);
-    return;
+    const empty = document.createElement('p');
+    empty.className = 'hint';
+    empty.textContent = q || currentPill !== 'all'
+      ? 'No crumbs match your filters yet.'
+      : 'No crumbs yet. Drop one from the Home doors or Day page.';
+    feedRoot.appendChild(empty);
+    return;
   }
 
   for(const [day, items] of groups){
-    const group = document.createElement('div');
-    group.className = 'day-group';
-
-    const coverCrumb = items.find(c=> Array.isArray(c.media) && c.media.find(m=>m.kind==='image'));
-    if(coverCrumb){
-      const imgObj = coverCrumb.media.find(m=>m.kind==='image');
-      const cover = document.createElement('div');
-      cover.className = 'cover';
-      cover.innerHTML = `<img src="${imgObj.dataUrl}" alt="" />`;
-      group.appendChild(cover);
-
-      const details = document.createElement('div');
-      details.className = 'day-details hidden';
-      const h = document.createElement('h3');
-      h.className = 'day-head';
-      h.textContent = day;
-      details.appendChild(h);
-      const nar = document.createElement('p');
-      nar.className = 'narrative';
-      nar.textContent = items.map(c=> c.text).join(' ');
-      details.appendChild(nar);
-      items.forEach(c=> details.appendChild(makeItem(c)));
-      group.appendChild(details);
-      cover.addEventListener('click', ()=> details.classList.toggle('hidden'));
-    }else{
-      const h = document.createElement('h3');
-      h.className = 'day-head';
-      h.textContent = day;
-      group.appendChild(h);
-      const nar = document.createElement('p');
-      nar.className = 'narrative';
-      nar.textContent = items.map(c=> c.text).join(' ');
-      group.appendChild(nar);
-      items.forEach(c=> group.appendChild(makeItem(c)));
-    }
-
-    feedRoot.appendChild(group);
+    feedRoot.appendChild(makePost(day, items));
   }
 }
 
-// chip interactions
+function setActivePill(pill){
+  const next = pill || 'all';
+  if(currentPill === next){
+    render();
+    return;
+  }
+  currentPill = next;
+  render();
+}
+
 if(chipRow){
-  chipRow.addEventListener('click', (e)=>{
-    const btn = e.target.closest('.chip');
+  chipRow.addEventListener('click', event => {
+    const btn = event.target.closest('.chip');
     if(!btn) return;
     const pill = btn.dataset.pill;
     if(!pill) return;
-    currentPill = pill;
-    // update active + aria-selected
-    chipRow.querySelectorAll('.chip').forEach(c=>{
-      const active = c === btn;
-      c.classList.toggle('is-active', active);
-      c.setAttribute('aria-selected', active ? 'true' : 'false');
-    });
-    render();
+    setActivePill(pill);
   });
 }
 
-// search interactions (debounced)
-let t = null;
+if(storyTrack){
+  storyTrack.addEventListener('click', event => {
+    const btn = event.target.closest('.story-chip');
+    if(!btn) return;
+    const pill = btn.dataset.pill;
+    if(!pill) return;
+    setActivePill(pill);
+  });
+}
+
+let debounceId = null;
 if(qInput){
-  qInput.addEventListener('input', ()=>{
-    clearTimeout(t);
-    t = setTimeout(()=>{ q = qInput.value || ''; render(); }, 150);
+  qInput.addEventListener('input', () => {
+    clearTimeout(debounceId);
+    debounceId = setTimeout(() => {
+      q = qInput.value || '';
+      render();
+    }, 150);
   });
 }
 
-// react to crumb changes while the page is open
 if(typeof window !== 'undefined'){
-  window.addEventListener('swirl:changed', (evt)=>{
+  window.addEventListener('swirl:changed', evt => {
     const type = evt.detail?.type || '';
-    if(type.startsWith('crumb_')) render();
+    if(type.startsWith('crumb_') || type === 'like_toggle'){
+      render();
+    }
   });
 }
 
-// initial render
 render();

--- a/jonah-swirl-school/swirlfeed.html
+++ b/jonah-swirl-school/swirlfeed.html
@@ -15,12 +15,17 @@
     </header>
     <p class="page-intro">Scroll this cozy feed to replay every crumb, filter by pillar, and open the ones you want to linger with a little longer.</p>
 
-    <!-- FILTER BAR -->
-    <section class="filters" aria-label="Filter crumbs">
-      <div class="chips" role="tablist">
-        <button class="chip is-active" data-pill="all" role="tab" aria-selected="true">All</button>
+    <!-- STORIES ROW -->
+    <section class="stories" aria-label="Pillar stories">
+      <div id="storyTrack" class="story-track" aria-live="polite"></div>
+    </section>
+
+    <!-- FILTER BAR -->
+    <section class="filters" aria-label="Filter crumbs">
+      <div class="chips" role="tablist">
+        <button class="chip is-active" data-pill="all" role="tab" aria-selected="true">All</button>
         <button class="chip" data-pill="divine" role="tab" aria-selected="false">👑 Spiritual Routine</button>
-        <button class="chip" data-pill="family" role="tab" aria-selected="false">🏠 Home</button>
+        <button class="chip" data-pill="family" role="tab" aria-selected="false">🏠 Home</button>
         <button class="chip" data-pill="self"   role="tab" aria-selected="false">🌱 Self</button>
         <button class="chip" data-pill="rrr"    role="tab" aria-selected="false">📚 Skills</button>
         <button class="chip" data-pill="work"   role="tab" aria-selected="false">💵 Work</button>


### PR DESCRIPTION
## Summary
- add a stories strip and IG-inspired feed cards so the page feels like a familiar social scroll
- rebuild the Swirlfeed renderer to support likes, crumb threads, sharing, and coordinated filters
- extend storage with a local like toggle helper for crumbs

## Testing
- not run (static HTML site)


------
https://chatgpt.com/codex/tasks/task_e_68c9bfa1b7c4832e9db7177bea07bb83