### PR TITLE
feat(hub): swap sprout spiral art, lock palette, simplify nav, recolor tokens with theme vars

### DIFF
--- a/jonah-swirl-school/css/base.css
+++ b/jonah-swirl-school/css/base.css
@@ -23,6 +23,11 @@
   --pillar-self:      #CFE8DF;  /* seafoam/minty */
   --pillar-rrr:       #BFD7F6;  /* sky blue */
   --pillar-work:      #FFB38A;  /* peach/apricot */
+  --token-divine: var(--pillar-spiritual);
+  --token-family: var(--pillar-family);
+  --token-self:   var(--pillar-self);
+  --token-rrr:    var(--pillar-rrr);
+  --token-work:   var(--pillar-work);
   --p-divine-100: rgba(207,169,242,0.22);
   --p-family-100: rgba(242,193,86,0.22);
   --p-self-100:   rgba(207,232,223,0.35);

--- a/jonah-swirl-school/css/hub.css
+++ b/jonah-swirl-school/css/hub.css
@@ -131,7 +131,6 @@ body{
   box-shadow: var(--hub-glow-strong);
   animation: breathe 6.5s ease-in-out infinite;
   z-index:5;
-  pointer-events:none;
 }
 .swirl::before{
   content:"";
@@ -155,11 +154,12 @@ body{
 .enter-day{
   position:absolute; left:50%; top:50%; transform:translate(-50%,-50%);
   width:96px; height:138px; border-radius:60px 60px 12px 12px;
-  background:transparent;
-  box-shadow:none;
+  background: radial-gradient(60% 50% at 50% 38%, color-mix(in srgb, var(--accent1) 42%, transparent) 0 60%, transparent 92%);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent1) 32%, transparent), 0 24px 42px -28px color-mix(in srgb, var(--accent1) 60%, transparent);
   border:0;
   display:block;
   z-index:6;
+  pointer-events:auto;
 }
 .enter-day:focus-visible{
   outline:3px solid color-mix(in srgb, var(--accent1) 60%, transparent);
@@ -169,6 +169,7 @@ body{
 /* ~lines 146-220: tokens (circles → doors) */
 .token{
   --size: 88px;
+  --token-color: var(--token-self);
   position:absolute; inset:auto;
   width:var(--size); height:var(--size); border-radius:50%;
   border:none; cursor:pointer;
@@ -177,13 +178,13 @@ body{
   color:color-mix(in srgb, var(--ink) 88%, transparent);
   font-weight:600; letter-spacing:0.2px;
   background:
-    radial-gradient(circle at 35% 28%, rgba(255,255,255,0.65), transparent 45%),
+    radial-gradient(circle at 35% 28%, color-mix(in srgb, var(--surface-strong) 85%, transparent) 0 45%, transparent 70%),
     linear-gradient(145deg,
-      hsl(var(--hue) var(--sat) calc(var(--lit) + 6%)),
-      hsl(var(--hue) calc(var(--sat) - 6%) calc(var(--lit) - 8%)));
+      color-mix(in srgb, var(--token-color) 88%, var(--surface) 12%),
+      color-mix(in srgb, var(--token-color) 82%, var(--ink) 18%));
   box-shadow:
     var(--hub-glow),
-    0 0 0 0 hsla(var(--hue), 60%, 60%, 0); /* reserved for hover aura */
+    0 0 0 0 color-mix(in srgb, var(--token-color) 55%, transparent); /* reserved for hover aura */
   transition: transform .25s ease, border-radius .35s ease, box-shadow .25s ease, width .35s ease, height .35s ease, background .35s ease;
   animation: drift linear infinite;
   z-index:4;
@@ -192,9 +193,22 @@ body{
 .token:hover{
   box-shadow:
     var(--hub-glow-strong),
-    0 0 18px 4px hsla(var(--hue), 60%, 60%, .25);
+    0 0 18px 4px color-mix(in srgb, var(--token-color) 65%, transparent);
   transform: translateZ(0) scale(1.045);
 }
+.token:focus-visible{
+  outline:none;
+  box-shadow:
+    var(--hub-glow-strong),
+    0 0 0 4px color-mix(in srgb, var(--token-color) 48%, transparent),
+    0 0 18px 6px color-mix(in srgb, var(--token-color) 62%, transparent);
+}
+
+.token[data-pillar="divine"]{ --token-color: var(--token-divine); }
+.token[data-pillar="family"]{ --token-color: var(--token-family); }
+.token[data-pillar="self"]{ --token-color: var(--token-self); }
+.token[data-pillar="rrr"]{ --token-color: var(--token-rrr); }
+.token[data-pillar="work"]{ --token-color: var(--token-work); }
 
 /* morph into ARCH DOOR on click (with wood slats + aura) */
 .token.door{
@@ -202,20 +216,20 @@ body{
   width:150px; height:190px;
   border-radius: 90px 90px 14px 14px; /* arch */
   background:
-    radial-gradient(circle at 38% 12%, rgba(255,255,255,0.75), transparent 40%),
+    radial-gradient(circle at 38% 12%, color-mix(in srgb, var(--surface-strong) 92%, transparent) 0 40%, transparent 68%),
     repeating-linear-gradient(90deg,
-      rgba(255,255,255,0.06) 0 7px,
-      rgba(0,0,0,0.06) 7px 9px),
+      color-mix(in srgb, var(--surface) 18%, transparent) 0 7px,
+      color-mix(in srgb, var(--ink) 10%, transparent) 7px 9px),
     linear-gradient(165deg,
-      hsl(var(--hue) var(--sat) calc(var(--lit) + 3%)),
-      hsl(var(--hue) calc(var(--sat) - 10%) calc(var(--lit) - 14%)));
+      color-mix(in srgb, var(--token-color) 86%, var(--surface) 14%),
+      color-mix(in srgb, var(--token-color) 72%, var(--ink) 22%));
   box-shadow:
     0 10px 26px rgba(var(--hub-shadow-rgb),0.20),
     0 0 0 1px rgba(var(--hub-shadow-rgb),0.10) inset,
-    0 0 24px 8px hsla(var(--hue), 60%, 60%, .35);
+    0 0 24px 8px color-mix(in srgb, var(--token-color) 60%, transparent);
   animation-play-state: paused; /* stop drifting when it becomes a door */
   position: relative;
-  outline: 2px solid rgba(var(--hub-shadow-rgb),0.12);
+  outline: 2px solid color-mix(in srgb, var(--token-color) 30%, transparent);
   outline-offset: 0;
   transition: box-shadow .3s ease, transform .25s ease;
 }
@@ -225,11 +239,11 @@ body{
   content:"";
   position:absolute; right:18px; top:54%;
   width:12px; height:12px; border-radius:50%;
-  background:rgba(0,0,0,0.42);
+  background:color-mix(in srgb, var(--ink) 70%, transparent);
   transform: translateY(-50%);
   box-shadow:
-    0 0 0 1px rgba(255,255,255,0.45) inset,
-    0 2px 4px rgba(0,0,0,0.25);
+    0 0 0 1px color-mix(in srgb, var(--surface) 72%, transparent) inset,
+    0 2px 4px color-mix(in srgb, var(--ink) 26%, transparent);
 }
 
 /* star glimmer that pulses on active door */
@@ -238,10 +252,10 @@ body{
   position:absolute; left:16%; top:20%;
   width:10px; height:10px;
   background:
-    radial-gradient(circle, #fff 0 40%, transparent 41%),
-    radial-gradient(circle at 50% 50%, rgba(255,255,255,.9), transparent 55%);
+    radial-gradient(circle, color-mix(in srgb, var(--surface-strong) 100%, transparent) 0 40%, transparent 41%),
+    radial-gradient(circle at 50% 50%, color-mix(in srgb, var(--surface) 92%, transparent), transparent 55%);
   border-radius:50%;
-  filter: drop-shadow(0 0 10px hsla(var(--hue), 80%, 70%, .6));
+  filter: drop-shadow(0 0 10px color-mix(in srgb, var(--token-color) 70%, transparent));
   animation: door-glimmer 3.6s ease-in-out infinite;
   opacity:0;
 }

--- a/jonah-swirl-school/css/landing.css
+++ b/jonah-swirl-school/css/landing.css
@@ -54,6 +54,70 @@
 /* -------------------------- */
 /* Temporary Instructions Box */
 /* -------------------------- */
+.intro-card {
+  position: absolute;
+  left: 50%;
+  bottom: clamp(32px, 11vh, 160px);
+  transform: translateX(-50%);
+  width: min(420px, calc(100vw - 48px));
+  margin: 0;
+  padding: 1.1rem 1.35rem 1.2rem;
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--surface-strong) 94%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent1) 28%, transparent);
+  box-shadow: var(--hub-glow);
+  backdrop-filter: blur(12px);
+  display: grid;
+  gap: 0.65rem;
+  color: color-mix(in srgb, var(--ink) 92%, transparent);
+  text-align: left;
+  z-index: 8;
+}
+
+.intro-card h2 {
+  font-size: 1.2rem;
+  margin: 0;
+  color: color-mix(in srgb, var(--accent1) 72%, var(--ink) 28%);
+}
+
+.intro-card p {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.intro-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--accent2) 46%, transparent);
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+  color: color-mix(in srgb, var(--ink) 80%, transparent);
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: var(--hub-glow);
+  display: grid;
+  place-items: center;
+}
+
+.intro-close:hover,
+.intro-close:focus-visible {
+  background: color-mix(in srgb, var(--accent1) 20%, var(--surface));
+  outline: none;
+}
+
+.intro-close:focus-visible {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent1) 42%, transparent);
+}
+
+.intro-card[hidden] {
+  display: none !important;
+}
+
 .instructions-box {
   position: absolute;
   left: 50%;
@@ -133,6 +197,7 @@
 }
 
 @media (max-width: 640px) {
+  .intro-card,
   .instructions-box {
     padding: 1rem 1.1rem;
     gap: 0.55rem;

--- a/jonah-swirl-school/index.html
+++ b/jonah-swirl-school/index.html
@@ -27,7 +27,7 @@
     <label class="visually-hidden" for="crumbBox">Drop a crumb</label>
     <input id="crumbBox" class="pill" placeholder="Drop a crumb…" x-webkit-speech />
 
-    <a class="btn btn-ghost" href="./weekly.html">🗓️ Schedule</a>
+    <a class="btn btn-ghost" href="./weekly.html">Weekly</a>
   </header>
 
   <!-- Pond / Landing -->
@@ -55,39 +55,22 @@
     </figure>
 
     <!-- Floating pillar tokens (positions styled in CSS; colors via CSS vars) -->
-    <button class="token" data-pillar="divine" data-app="Spiritual Routine" style="--hue:288;--sat:58%;--lit:70%;">Spiritual Routine</button>
-    <button class="token" data-pillar="self"   data-app="Self"               style="--hue:96; --sat:62%;--lit:68%;">Self</button>
-    <button class="token" data-pillar="family" data-app="Family &amp; Home"  style="--hue:42; --sat:72%;--lit:66%;">Family</button>
-    <button class="token" data-pillar="rrr"    data-app="RRR"                style="--hue:210;--sat:65%;--lit:72%;">RRR</button>
-    <button class="token" data-pillar="work"   data-app="Work"               style="--hue:12; --sat:70%;--lit:68%;">Work</button>
+    <button class="token" data-pillar="divine" data-app="Spiritual Routine">Spiritual Routine</button>
+    <button class="token" data-pillar="self" data-app="Self">Self</button>
+    <button class="token" data-pillar="family" data-app="Family &amp; Home">Family</button>
+    <button class="token" data-pillar="rrr" data-app="RRR">RRR</button>
+    <button class="token" data-pillar="work" data-app="Work">Work</button>
 
     <!-- Dismissible intro card (temporary helper copy) -->
     <aside id="introCard" class="intro-card" role="dialog" aria-modal="false" aria-labelledby="introTitle">
       <button id="introDismiss" class="intro-close" aria-label="Dismiss help">×</button>
       <h2 id="introTitle">Start at the hub</h2>
-      <p>Feel today’s glow and choose the door you need. Tap the bright center when you’re ready to drop a crumb for the day.</p>
+      <p>Tap the bright center when you’re ready to drop a crumb for the day.</p>
     </aside>
   </main>
 
   <!-- Scripts -->
   <script type="module">
-    // Minimal helpers to keep the page interactive without extra globals.
-
-    // Mode buttons (stubbed – actual routing can live in hub.js)
-    const btnSwirl = document.getElementById('btnSwirl');
-    const btnStructured = document.getElementById('btnStructured');
-    btnSwirl?.addEventListener('click', () => {
-      document.body.classList.add('mode-swirl');
-      btnSwirl.setAttribute('aria-pressed','true');
-      btnStructured.setAttribute('aria-pressed','false');
-    });
-    btnStructured?.addEventListener('click', () => {
-      document.body.classList.remove('mode-swirl');
-      btnStructured.setAttribute('aria-pressed','true');
-      btnSwirl.setAttribute('aria-pressed','false');
-      // optional: window.location.href = './index-structured.html';
-    });
-
     // Intro card dismiss (persist once per browser using localStorage)
     const intro = document.getElementById('introCard');
     const introBtn = document.getElementById('introDismiss');
@@ -96,22 +79,6 @@
     introBtn?.addEventListener('click', () => {
       intro?.setAttribute('hidden','');
       localStorage.setItem(INTRO_KEY, '1');
-    });
-
-    // Token clicks → route user (these can be refined later)
-    const map = {
-      divine: './day.html#divine',
-      self: './day.html#self',
-      family: './day.html#family',
-      rrr: './day.html#rrr',
-      work: './day.html#work'
-    };
-    document.querySelectorAll('.token').forEach(btn => {
-      btn.addEventListener('click', () => {
-        const key = btn.getAttribute('data-pillar');
-        const href = map[key] || './day.html';
-        window.location.href = href;
-      });
     });
   </script>
 

--- a/jonah-swirl-school/js/hub.js
+++ b/jonah-swirl-school/js/hub.js
@@ -97,8 +97,14 @@ const crumbBox      = document.getElementById('crumbBox');
 function setMode(mode){
   document.body.classList.toggle('mode-swirl',      mode === 'swirl');
   document.body.classList.toggle('mode-structured', mode === 'structured');
-  btnSwirl.classList.toggle('active',      mode === 'swirl');
-  btnStructured.classList.toggle('active', mode === 'structured');
+  if(btnSwirl){
+    btnSwirl.classList.toggle('active', mode === 'swirl');
+    btnSwirl.setAttribute('aria-pressed', mode === 'swirl' ? 'true' : 'false');
+  }
+  if(btnStructured){
+    btnStructured.classList.toggle('active', mode === 'structured');
+    btnStructured.setAttribute('aria-pressed', mode === 'structured' ? 'true' : 'false');
+  }
 
   if(mode === 'structured'){
     tokens.forEach((t, i) => {
@@ -109,8 +115,8 @@ function setMode(mode){
   }
 }
 
-btnSwirl.addEventListener('click',      () => setMode('swirl'));
-btnStructured.addEventListener('click', () => setMode('structured'));
+btnSwirl?.addEventListener('click',      () => setMode('swirl'));
+btnStructured?.addEventListener('click', () => setMode('structured'));
 
 if(crumbBox){
   crumbBox.addEventListener('keydown', (e)=>{
@@ -125,17 +131,3 @@ if(crumbBox){
 // start in mode based on hash (#structured) or default to Swirlface
 const initialMode = location.hash === '#structured' ? 'structured' : 'swirl';
 setMode(initialMode);
-
-// draw smooth spiral
-function makeSpiralPath({cx=100, cy=100, startR=5, spacing=4, turns=4, steps=360}={}){
-  const TAU=Math.PI*2,total=turns*TAU,k=spacing/(2*Math.PI);
-  let d="";
-  for(let i=0;i<=steps;i++){
-    const t=i/steps,th=t*total+0.0001,r=startR+k*th;
-    const x=cx+r*Math.cos(th),y=cy+r*Math.sin(th);
-    d+= (i?` L ${x.toFixed(2)} ${y.toFixed(2)}`:`M ${x.toFixed(2)} ${y.toFixed(2)}`);
-  }
-  return d;
-}
-const spiralPath=document.getElementById('spiralPath');
-if(spiralPath){ spiralPath.setAttribute('d', makeSpiralPath()); }


### PR DESCRIPTION
## Summary
- swap the placeholder spiral for the sprout SVG, simplify the helper copy, and keep the toolbar lean
- restyle the swirl hub glow and token gradients to pull from palette variables while centering the enter-day hotspot
- map pillar colors to reusable token vars and refresh the intro card treatment to stay within the pastel theme

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9d9f4b488832e9076b3523f5fe285