### PR TITLE
feat: polish swirl hero, palette, hotspot, and token orbits

### DIFF
--- a/jonah-swirl-school/css/base.css
+++ b/jonah-swirl-school/css/base.css
@@ -35,14 +35,14 @@
   --p-work-100:   rgba(255,179,138,0.30);
 
   /* supportive pastels from the photo */
-  --pastel-pink:   #F7B3C8;
+  --pastel-pink:   hsl(343 84% 81%);
   --pastel-lilac:  #D9A7E1;
-  --pastel-peach:  #FFC29B;
+  --pastel-peach:  hsl(26 92% 83%);
   --pastel-butter: #F7E5A3;
-  --pastel-sky:    #A7C7E7;
+  --pastel-sky:    hsl(204 67% 79%);
 
   /* accents carried over from previous theme */
-  --accent1: #8FD5C4;   /* mint aqua shimmer */
+  --accent1: hsl(161 53% 69%);   /* mint aqua shimmer */
   --accent2: #FF9DD8;   /* Lucy pink sparkle */
   --accent3: #F0BC06;   /* golden encouragement */
 

--- a/jonah-swirl-school/css/hub.css
+++ b/jonah-swirl-school/css/hub.css
@@ -6,14 +6,14 @@
 /* ~lines 6-38: base + palette */
 :root{
   --hub-shadow-rgb: 27,31,51;
-  --hub-glow: 0 12px 26px rgba(var(--hub-shadow-rgb),0.12), 0 0 0 1px rgba(var(--hub-shadow-rgb),0.06);
-  --hub-glow-strong: 0 18px 42px rgba(var(--hub-shadow-rgb),0.18), 0 0 0 1px rgba(var(--hub-shadow-rgb),0.08);
-  --hub-veil: color-mix(in srgb, var(--surface) 72%, transparent);
-  --hub-ring: color-mix(in srgb, var(--ink) 12%, transparent);
-  --hub-bg-peach: color-mix(in srgb, var(--pastel-peach) 68%, transparent);
-  --hub-bg-sky: color-mix(in srgb, var(--pastel-sky) 70%, transparent);
-  --hub-bg-pink: color-mix(in srgb, var(--pastel-pink) 60%, transparent);
-  --hub-bg-mint: color-mix(in srgb, var(--accent1) 65%, transparent);
+  --hub-glow: 0 8px 22px rgba(var(--hub-shadow-rgb),0.12), 0 0 0 1px rgba(var(--hub-shadow-rgb),0.04);
+  --hub-glow-strong: 0 20px 44px rgba(var(--hub-shadow-rgb),0.16), 0 0 0 1px rgba(var(--hub-shadow-rgb),0.06);
+  --hub-veil: color-mix(in srgb, var(--surface) 82%, transparent);
+  --hub-ring: color-mix(in srgb, var(--accent1) 22%, transparent);
+  --hub-bg-peach: color-mix(in srgb, var(--pastel-peach) 70%, transparent);
+  --hub-bg-sky: color-mix(in srgb, var(--pastel-sky) 68%, transparent);
+  --hub-bg-pink: color-mix(in srgb, var(--pastel-pink) 62%, transparent);
+  --hub-bg-mint: color-mix(in srgb, var(--accent1) 64%, transparent);
 }
 
 * { box-sizing:border-box; }
@@ -23,28 +23,43 @@ body{
   color:var(--ink);
   font: 16px/1.45 ui-sans-serif, system-ui, -apple-system, Segoe UI, Inter, Roboto, Arial, sans-serif;
   background:
-    radial-gradient(1200px 840px at 18% 0%, var(--hub-bg-peach), transparent 64%),
-    radial-gradient(1020px 900px at 85% 12%, var(--hub-bg-sky), transparent 60%),
-    radial-gradient(1100px 940px at 12% 90%, var(--hub-bg-pink), transparent 58%),
-    radial-gradient(960px 880px at 88% 88%, var(--hub-bg-mint), transparent 60%),
+    radial-gradient(1200px 840px at 18% -10%, color-mix(in srgb, var(--hub-bg-peach) 82%, var(--surface) 18%) 0 68%, transparent 76%),
+    radial-gradient(1100px 920px at 85% 6%, color-mix(in srgb, var(--hub-bg-sky) 78%, var(--surface) 22%) 0 72%, transparent 78%),
+    radial-gradient(1080px 940px at 14% 88%, color-mix(in srgb, var(--hub-bg-pink) 80%, transparent) 0 70%, transparent 82%),
+    radial-gradient(960px 880px at 86% 92%, color-mix(in srgb, var(--hub-bg-mint) 82%, var(--surface) 18%) 0 66%, transparent 82%),
     var(--paper);
   background-attachment: fixed;
 }
 
 /* ~lines 40-78: toolbar */
 .lab-toolbar{
-  position:fixed; inset: 16px 16px auto 16px;
-  display:flex; align-items:center; justify-content:space-between;
-  gap:16px; padding:10px 12px;
-  background:var(--hub-veil);
-  backdrop-filter: blur(8px);
-  border-radius:14px; box-shadow: var(--hub-glow);
+  position:fixed;
+  top:clamp(12px, 3vw, 24px);
+  left:50%;
+  transform:translateX(-50%);
+  width:min(680px, calc(100% - clamp(28px, 8vw, 72px)));
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:clamp(8px, 2.6vw, 14px);
+  padding:8px 14px;
+  background:color-mix(in srgb, var(--hub-veil) 88%, transparent);
+  backdrop-filter: blur(12px);
+  border-radius:14px;
+  box-shadow: var(--hub-glow);
   border:1px solid var(--hub-ring);
-  z-index: 10;
+  z-index:12;
+  flex-wrap:wrap;
 }
-.brand{ display:flex; align-items:center; gap:10px; }
+.brand{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  font-size:0.95rem;
+  letter-spacing:0.4px;
+}
 .swirl-dot{
-  width:18px; height:18px; border-radius:50%;
+  width:16px; height:16px; border-radius:50%;
   background:conic-gradient(from 0deg,
     var(--pastel-sky),
     var(--pastel-peach),
@@ -52,21 +67,68 @@ body{
     var(--accent1),
     var(--pastel-sky)
   );
-  box-shadow: 0 0 0 1px var(--hub-ring) inset;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent1) 30%, transparent) inset;
 }
 .pill{
-  appearance:none; border:0; border-radius:999px; padding:8px 14px;
-  background:var(--surface-strong);
+  appearance:none;
+  border:0;
+  border-radius:999px;
+  padding:7px 16px;
+  background:color-mix(in srgb, var(--surface) 90%, transparent);
   box-shadow: var(--hub-glow);
   cursor:pointer;
   color:var(--ink);
+  font-size:0.95rem;
 }
 .pill.active{
-  background:var(--surface);
+  background:color-mix(in srgb, var(--surface-strong) 94%, transparent);
   box-shadow: var(--hub-glow-strong);
 }
-.modes{ display:flex; gap:8px; }
-#crumbBox{ flex:1; min-width:160px; }
+.modes{
+  display:flex;
+  gap:8px;
+  flex:0 0 auto;
+}
+#crumbBox{
+  flex:1 1 clamp(200px, 42vw, 320px);
+  min-width:clamp(180px, 38vw, 280px);
+  background:color-mix(in srgb, var(--surface-strong) 96%, transparent);
+  border:1px solid color-mix(in srgb, var(--accent1) 22%, transparent);
+  cursor:text;
+}
+#crumbBox::placeholder{
+  color:color-mix(in srgb, var(--ink) 58%, transparent);
+}
+
+@media (max-width: 640px){
+  .lab-toolbar{
+    width:min(92vw, 540px);
+    gap:10px;
+  }
+  .modes{
+    width:100%;
+    justify-content:center;
+  }
+  #crumbBox{
+    flex-basis:100%;
+    min-width:100%;
+  }
+  #pond{
+    padding-top: clamp(210px, 50vh, 320px);
+    padding-bottom: clamp(200px, 46vh, 300px);
+  }
+  .site-banner{
+    top:clamp(140px, 34vh, 220px);
+    width:min(420px, calc(100vw - 48px));
+    padding:0.45rem 1.25rem 0.75rem;
+  }
+}
+
+@media (max-width: 420px){
+  .lab-toolbar{
+    padding:8px 10px;
+  }
+}
 
 /* ~lines 80-144: pond + swirl + ripples */
 #pond{
@@ -76,15 +138,21 @@ body{
   overflow:hidden;
   display:grid;
   place-items:center;
-  padding: clamp(140px, 24vh, 220px) 0;
+  padding: clamp(180px, 34vh, 260px) clamp(20px, 6vw, 48px) clamp(180px, 40vh, 280px);
 }
 
 .site-banner{
   position:absolute;
-  top:clamp(88px, 18vh, 160px);
+  top:clamp(112px, 22vh, 188px);
   left:50%; transform:translateX(-50%);
   text-align:center;
-  z-index:6; pointer-events:none;
+  width:min(460px, calc(100vw - 96px));
+  padding:0.5rem 1.5rem 0.9rem;
+  border-radius:18px;
+  background:color-mix(in srgb, var(--surface) 82%, transparent);
+  box-shadow:0 12px 32px -20px color-mix(in srgb, var(--accent1) 35%, transparent);
+  backdrop-filter: blur(12px);
+  z-index:9; pointer-events:none;
 }
 .site-banner h1{
   margin:0; font-size:2.1rem; font-weight:700;
@@ -96,8 +164,8 @@ body{
   -webkit-background-clip:text; color:transparent;
 }
 .site-banner p{
-  margin:6px 0 0; font-size:1.15rem; letter-spacing:0.5px;
-  color:color-mix(in srgb, var(--ink) 82%, transparent);
+  margin:6px 0 0; font-size:1.1rem; letter-spacing:0.5px;
+  color:color-mix(in srgb, var(--ink) 78%, transparent);
 }
 
 /* soft rippling field (a hair stronger so rings read) */
@@ -106,17 +174,19 @@ body{
   position:absolute;
   inset:-22%;
   background:
-    radial-gradient(circle at 50% 46%, color-mix(in srgb, var(--surface-strong) 88%, transparent) 0 40%, transparent 70%),
+    radial-gradient(circle at 50% 42%, color-mix(in srgb, var(--pastel-peach) 28%, transparent) 0 34%, transparent 72%),
+    radial-gradient(circle at 52% 60%, color-mix(in srgb, var(--accent1) 26%, transparent) 0 20%, transparent 46%),
+    radial-gradient(circle at 48% 38%, color-mix(in srgb, var(--pastel-pink) 24%, transparent) 0 18%, transparent 56%),
     repeating-radial-gradient(circle at 50% 50%,
-      color-mix(in srgb, var(--surface) 75%, transparent) 0 2px,
-      transparent 2px 12px);
+      color-mix(in srgb, var(--surface) 78%, transparent) 0 2px,
+      transparent 2px 14px);
   mix-blend-mode: soft-light;
-  animation: ripple 16s ease-in-out infinite;
+  animation: ripple 22s ease-in-out infinite;
   pointer-events:none;
 }
 @keyframes ripple{
   0%,100%{ transform: scale(1); opacity:0.6; }
-  50%    { transform: scale(1.06); opacity:0.8; }
+  50%    { transform: scale(1.05); opacity:0.82; }
 }
 
 .swirl{
@@ -126,47 +196,102 @@ body{
   border-radius:50%;
   display:grid;
   place-items:center;
-  padding: clamp(14px, 3vw, 28px);
-  background: radial-gradient(68% 64% at 50% 38%, color-mix(in srgb, var(--surface-strong) 92%, transparent) 0 48%, transparent 76%);
-  box-shadow: var(--hub-glow-strong);
+  padding: clamp(18px, 3.4vw, 32px);
+  background:
+    radial-gradient(64% 58% at 50% 40%, color-mix(in srgb, var(--surface-strong) 95%, transparent) 0 52%, transparent 78%),
+    radial-gradient(86% 82% at 50% 32%, color-mix(in srgb, var(--accent1) 24%, transparent) 0 70%, transparent 86%);
+  box-shadow:
+    0 28px 60px -34px color-mix(in srgb, var(--accent1) 42%, transparent),
+    var(--hub-glow-strong);
   animation: breathe 6.5s ease-in-out infinite;
-  z-index:5;
+  z-index:7;
+  isolation:isolate;
 }
 .swirl::before{
   content:"";
   position:absolute;
-  inset:-28px;
+  inset:-34px;
   border-radius:50%;
   background:
-    radial-gradient(75% 75% at 50% 50%, color-mix(in srgb, var(--hub-bg-mint) 55%, transparent) 0 52%, transparent 90%),
-    radial-gradient(88% 88% at 50% 30%, color-mix(in srgb, var(--hub-bg-peach) 55%, transparent) 0 35%, transparent 75%);
-  opacity:0.8;
-  filter: blur(2px);
-  z-index:-1;
+    radial-gradient(78% 74% at 50% 54%, color-mix(in srgb, var(--pastel-peach) 42%, transparent) 0 56%, transparent 92%),
+    radial-gradient(72% 68% at 52% 32%, color-mix(in srgb, var(--pastel-pink) 46%, transparent) 0 48%, transparent 84%),
+    radial-gradient(86% 82% at 50% 70%, color-mix(in srgb, var(--accent1) 40%, transparent) 0 34%, transparent 84%);
+  opacity:0.85;
+  filter: blur(8px);
+  z-index:-2;
 }
 @keyframes breathe{ 0%,100%{ transform:scale(1)} 50%{ transform:scale(1.03)} }
 .swirl-svg{
   width:82%;
   height:82%;
   position:relative;
+  object-fit:contain;
+  display:block;
   z-index:1;
 }
 .enter-day{
   position:absolute; left:50%; top:50%; transform:translate(-50%,-50%);
-  width:96px; height:138px; border-radius:60px 60px 12px 12px;
-  background: radial-gradient(60% 50% at 50% 38%, color-mix(in srgb, var(--accent1) 42%, transparent) 0 60%, transparent 92%);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent1) 32%, transparent), 0 24px 42px -28px color-mix(in srgb, var(--accent1) 60%, transparent);
+  width:clamp(96px, 14vw, 128px);
+  height:clamp(118px, 18vw, 156px);
+  border-radius:64px;
+  background: radial-gradient(64% 58% at 50% 32%, color-mix(in srgb, var(--accent1) 38%, transparent) 0 58%, transparent 84%);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--accent1) 36%, transparent),
+    0 22px 46px -30px color-mix(in srgb, var(--accent1) 60%, transparent);
   border:0;
   display:block;
   z-index:6;
   pointer-events:auto;
+  transition: box-shadow .25s ease, transform .3s ease;
+}
+.enter-day::before{
+  content:"";
+  position:absolute;
+  inset:-28px;
+  border-radius:inherit;
+  background:
+    radial-gradient(62% 60% at 50% 32%, color-mix(in srgb, var(--pastel-pink) 36%, transparent) 0 56%, transparent 84%),
+    radial-gradient(62% 64% at 50% 64%, color-mix(in srgb, var(--accent1) 30%, transparent) 0 48%, transparent 86%);
+  opacity:0.85;
+  filter: blur(18px);
+  z-index:-1;
+}
+.enter-day::after{
+  content:"";
+  position:absolute;
+  inset:22% 26% 26%;
+  border-radius:50%;
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  opacity:0.75;
+}
+.enter-day:hover,
+.enter-day:focus-visible{
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--accent1) 42%, transparent),
+    0 26px 44px -26px color-mix(in srgb, var(--pastel-pink) 44%, transparent);
+  transform:translate(-50%,-50%) scale(1.03);
 }
 .enter-day:focus-visible{
-  outline:3px solid color-mix(in srgb, var(--accent1) 60%, transparent);
+  outline:3px solid color-mix(in srgb, var(--accent1) 62%, transparent);
   outline-offset:8px;
 }
 
 /* ~lines 146-220: tokens (circles → doors) */
+.intro-card{
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  gap:0.6rem;
+  padding:1rem 1.35rem 1.05rem;
+  text-align:center;
+  line-height:1.4;
+}
+.intro-card p{
+  margin:0;
+  font-size:1rem;
+  letter-spacing:0.12px;
+}
+
 .token{
   --size: 88px;
   --token-color: var(--token-self);

--- a/jonah-swirl-school/index.html
+++ b/jonah-swirl-school/index.html
@@ -24,10 +24,7 @@
       <button id="btnStructured" class="pill" aria-pressed="false">Structured</button>
     </nav>
 
-    <label class="visually-hidden" for="crumbBox">Drop a crumb</label>
-    <input id="crumbBox" class="pill" placeholder="Drop a crumb…" x-webkit-speech />
-
-    <a class="btn btn-ghost" href="./weekly.html">Weekly</a>
+    <input id="crumbBox" class="pill" type="text" placeholder="Drop a crumb…" aria-label="Drop a crumb" x-webkit-speech />
   </header>
 
   <!-- Pond / Landing -->
@@ -43,13 +40,7 @@
 
     <!-- Center spiral (no central door) -->
     <figure class="swirl" aria-label="Swirl hub">
-      <img
-        src="./assets/spiral-sprout.svg"
-        alt="Hand-drawn spiral with sprout"
-        class="swirl-svg"
-        decoding="async"
-        fetchpriority="high"
-      />
+      <img src="./assets/spiral-sprout.svg" alt="Hand-drawn spiral with sprout" class="swirl-svg" decoding="async" fetchpriority="high" />
       <!-- Enter Day hotspot (ring in the bright center) -->
       <a id="enterDay" class="enter-day" href="./day.html" aria-label="Enter Day"></a>
     </figure>
@@ -62,10 +53,9 @@
     <button class="token" data-pillar="work" data-app="Work">Work</button>
 
     <!-- Dismissible intro card (temporary helper copy) -->
-    <aside id="introCard" class="intro-card" role="dialog" aria-modal="false" aria-labelledby="introTitle">
+    <aside id="introCard" class="intro-card" role="dialog" aria-modal="false" aria-labelledby="introCopy">
       <button id="introDismiss" class="intro-close" aria-label="Dismiss help">×</button>
-      <h2 id="introTitle">Start at the hub</h2>
-      <p>Tap the bright center when you’re ready to drop a crumb for the day.</p>
+      <p id="introCopy">Tap the bright center to drop a crumb for today.</p>
     </aside>
   </main>
 

--- a/jonah-swirl-school/js/hub.js
+++ b/jonah-swirl-school/js/hub.js
@@ -68,14 +68,18 @@ function quickSaveCrumb(){
 function rand(min, max){ return Math.random() * (max - min) + min; }
 
 tokens.forEach((t, i) => {
-  // randomize orbits so each circle feels alive
-  const startAngle = rand(0, 360);
-  const radius     = rand(150, 260);      // distance from center
+  // randomize orbits so each circle feels alive while remaining evenly spaced
+  const slice      = 360 / tokens.length;
+  const offset     = rand(-18, 18);
+  const startAngle = (slice * i + offset + 360) % 360;
+  const radius     = rand(170, 240);      // distance from center
   const duration   = rand(26, 46);        // seconds per revolution
 
   t.style.setProperty('--angle', `${startAngle}deg`);
   t.style.setProperty('--radius', `${radius}px`);
   t.style.animationDuration = `${duration}s`;
+  t.dataset.swirlAngle = startAngle.toFixed(2);
+  t.dataset.swirlRadius = radius.toFixed(2);
 });
 
 // ~lines 20-40: click → navigate to pillar feed
@@ -111,6 +115,13 @@ function setMode(mode){
       const angle = (360 / tokens.length) * i;
       t.style.setProperty('--angle', `${angle}deg`);
       t.style.setProperty('--radius', `210px`);
+    });
+  }else{
+    tokens.forEach((t) => {
+      const angle  = t.dataset.swirlAngle;
+      const radius = t.dataset.swirlRadius;
+      if(angle)  t.style.setProperty('--angle', `${angle}deg`);
+      if(radius) t.style.setProperty('--radius', `${radius}px`);
     });
   }
 }


### PR DESCRIPTION
## Summary
- lighten the floating toolbar and banner spacing so the hero stays clear on small screens
- refresh the swirl hero with the hand-drawn spiral art, a glowing drop target, and a single-line helper card
- tune pastel palette tokens and orbit logic so tokens stay evenly spaced and structured mode snaps cleanly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9e1360804832e8ed6c7f78fbb0e45